### PR TITLE
Add interactive exercises to generated lessons

### DIFF
--- a/output/a2/gruppe_1_familie/01_Otets_i_docheri_A2.html
+++ b/output/a2/gruppe_1_familie/01_Otets_i_docheri_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 1: ОТЕЦ И ДОЧЕРИ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -876,7 +877,424 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="семья">
+                    <span class="word-main">die Familie</span>
+                    <small class="word-hint">[ди фа-МИ-ли-е]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="воспитывать">
+                    <span class="word-main">erziehen</span>
+                    <small class="word-hint">[ер-ЦИ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="расставаться">
+                    <span class="word-main">sich trennen</span>
+                    <small class="word-hint">[зих ТРЕН-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="ссориться">
+                    <span class="word-main">streiten</span>
+                    <small class="word-hint">[ШТРАЙ-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="отец">
+                    <span class="word-main">der Vater</span>
+                    <small class="word-hint">[дер ФА-тер]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="выходить замуж">
+                    <span class="word-main">heiraten</span>
+                    <small class="word-hint">[ХАЙ-ра-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="дочь">
+                    <span class="word-main">die Tochter</span>
+                    <small class="word-hint">[ди ТОХ-тер]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="вырастать">
+                    <span class="word-main">aufwachsen</span>
+                    <small class="word-hint">[АУФ-вак-сен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="выходить замуж">
+                    выходить замуж
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="дочь">
+                    дочь
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="ссориться">
+                    ссориться
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="семья">
+                    семья
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="отец">
+                    отец
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="вырастать">
+                    вырастать
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="воспитывать">
+                    воспитывать
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="расставаться">
+                    расставаться
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Vater</span>
+                        <small>отец</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Familie</span>
+                        <small>семья</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Tochter</span>
+                        <small>дочь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>verzeihen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>ссориться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>понимать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>прощать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>отец</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>verwandt</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>дочь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>любить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>родственный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>воспитывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>aufwachsen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>дочь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>понимать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>выходить замуж</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>вырастать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Tochter</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>семья</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>дочь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>выходить замуж</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>отец</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Familie</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>понимать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>выходить замуж</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>семья</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>любить</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Ich bin euer _____!</p>
+                    <p class="context-hint">Подсказка: Я ваш ОТЕЦ!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Vater">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich bin Eure _____</p>
+                    <p class="context-hint">Подсказка: Я ваша ДОЧЬ</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Tochter">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Unsere _____!</p>
+                    <p class="context-hint">Подсказка: Наша СЕМЬЯ!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Familie">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я ваш ОТЕЦ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">euer</span><span class="draggable" draggable="true">bin</span><span class="draggable" draggable="true">VATER</span></div>
+                    <div class="drop-zone" data-correct="Ich bin euer VATER">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Вы мои ДОЧЕРИ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">TÖCHTER</span><span class="draggable" draggable="true">seid</span><span class="draggable" draggable="true">Ihr</span><span class="draggable" draggable="true">meine</span></div>
+                    <div class="drop-zone" data-correct="Ihr seid meine TÖCHTER">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1164,7 +1582,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_1_familie/02_Bratya_A2.html
+++ b/output/a2/gruppe_1_familie/02_Bratya_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 2: БРАТЬЯ - ЭДГАР И ЭДМУНД</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -860,7 +861,472 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="предавать">
+                    <span class="word-main">verraten</span>
+                    <small class="word-hint">[фер-РА-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="письмо">
+                    <span class="word-main">der Brief</span>
+                    <small class="word-hint">[дер БРИФ]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="сын">
+                    <span class="word-main">der Sohn</span>
+                    <small class="word-hint">[дер ЗОН]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="бежать">
+                    <span class="word-main">fliehen</span>
+                    <small class="word-hint">[ФЛИ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="наследство">
+                    <span class="word-main">das Erbe</span>
+                    <small class="word-hint">[дас ЕР-бе]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="честный">
+                    <span class="word-main">ehrlich</span>
+                    <small class="word-hint">[ЕР-лих]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="месть">
+                    <span class="word-main">die Rache</span>
+                    <small class="word-hint">[ди РА-хе]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="бастард">
+                    <span class="word-main">der Bastard</span>
+                    <small class="word-hint">[дер БАС-тард]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="наследство">
+                    наследство
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="бастард">
+                    бастард
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="сын">
+                    сын
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="предавать">
+                    предавать
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="честный">
+                    честный
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="месть">
+                    месть
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="бежать">
+                    бежать
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="письмо">
+                    письмо
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Brief</span>
+                        <small>письмо</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Bastard</span>
+                        <small>бастард</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Rache</span>
+                        <small>месть</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Bruder</span>
+                        <small>брат</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Sohn</span>
+                        <small>сын</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Wahnsinn</span>
+                        <small>безумие</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Erbe</span>
+                        <small>наследство</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>das Erbe</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>честный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>сын</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>наследство</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>бастард</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>der Brief</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>месть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>письмо</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>сын</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>честный</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>der Bruder</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>предавать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>брат</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>честный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>безумие</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>der Sohn</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>злой</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>честный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>брат</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>сын</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>böse</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>брат</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>письмо</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>злой</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>месть</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Mein _____ Edgar!</p>
+                    <p class="context-hint">Подсказка: Мой БРАТ Эдгар!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Bruder">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Mein _____ Edgar!</p>
+                    <p class="context-hint">Подсказка: Мой СЫН Эдгар!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Sohn">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich bin ein _____!</p>
+                    <p class="context-hint">Подсказка: Я БАСТАРД!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Bastard">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Почему я должен страдать из-за того, что я БАСТАРД</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">weil</span><span class="draggable" draggable="true">ein</span><span class="draggable" draggable="true">leiden</span><span class="draggable" draggable="true">BASTARD</span><span class="draggable" draggable="true">Warum</span><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">bin</span><span class="draggable" draggable="true">sollte</span></div>
+                    <div class="drop-zone" data-correct="Warum sollte ich leiden weil ich ein BASTARD bin">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Мой БРАТ Эдгар имеет всё - НАСЛЕДСТВО, любовь</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Mein</span><span class="draggable" draggable="true">alles</span><span class="draggable" draggable="true">ERBE</span><span class="draggable" draggable="true">Edgar</span><span class="draggable" draggable="true">Liebe</span><span class="draggable" draggable="true">hat</span><span class="draggable" draggable="true">BRUDER</span><span class="draggable" draggable="true">die</span><span class="draggable" draggable="true">das</span></div>
+                    <div class="drop-zone" data-correct="Mein BRUDER Edgar hat alles das ERBE die Liebe">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1148,7 +1614,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_1_familie/03_Predatelstvo_semi_A2.html
+++ b/output/a2/gruppe_1_familie/03_Predatelstvo_semi_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 3: ПРЕДАТЕЛЬСТВО СЕМЬИ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -861,7 +862,448 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="обманывать видимостью">
+                    <span class="word-main">täuschen</span>
+                    <small class="word-hint">[ТОЙ-шен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="разочаровывать">
+                    <span class="word-main">enttäuschen</span>
+                    <small class="word-hint">[ент-ТОЙ-шен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="правда">
+                    <span class="word-main">die Wahrheit</span>
+                    <small class="word-hint">[ди ВАР-хайт]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="предательство">
+                    <span class="word-main">der Verrat</span>
+                    <small class="word-hint">[дер фер-РАТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="доверять">
+                    <span class="word-main">vertrauen</span>
+                    <small class="word-hint">[фер-ТРАУ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="обманывать">
+                    <span class="word-main">betrügen</span>
+                    <small class="word-hint">[бе-ТРЮ-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="фальшивый">
+                    <span class="word-main">falsch</span>
+                    <small class="word-hint">[ФАЛЬШ]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="лицемерие">
+                    <span class="word-main">die Heuchelei</span>
+                    <small class="word-hint">[ди хой-хе-ЛАЙ]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="лицемерие">
+                    лицемерие
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="правда">
+                    правда
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="предательство">
+                    предательство
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="доверять">
+                    доверять
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="обманывать видимостью">
+                    обманывать видимостью
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="разочаровывать">
+                    разочаровывать
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="обманывать">
+                    обманывать
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="фальшивый">
+                    фальшивый
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Wahrheit</span>
+                        <small>правда</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Verrat</span>
+                        <small>предательство</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Treue</span>
+                        <small>верность</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Heuchelei</span>
+                        <small>лицемерие</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Lüge</span>
+                        <small>ложь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>falsch</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>фальшивый</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>предавать исподтишка</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>обманывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>правда</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>die Treue</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>доверять</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>верность</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>предательство</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>правда</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>betrügen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>обманывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>верность</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>доверять</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>фальшивый</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>der Verrat</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>разочаровывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>предательство</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>фальшивый</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>обманывать видимостью</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Wahrheit</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>правда</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>предательство</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>обманывать видимостью</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>обманывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Ist das _____?</p>
+                    <p class="context-hint">Подсказка: Это ПРЕДАТЕЛЬСТВО?</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Verrat">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Das ist eine _____!</p>
+                    <p class="context-hint">Подсказка: Это ЛОЖЬ!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Lüge">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich sage die _____!</p>
+                    <p class="context-hint">Подсказка: Я говорю ПРАВДУ!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Wahrheit">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Наше ЛИЦЕМЕРИЕ сработало</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">HEUCHELEI</span><span class="draggable" draggable="true">Unsere</span><span class="draggable" draggable="true">hat</span><span class="draggable" draggable="true">funktioniert</span></div>
+                    <div class="drop-zone" data-correct="Unsere HEUCHELEI hat funktioniert">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">ПРАВДА изгнана, ЛОЖЬ царствует</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">die</span><span class="draggable" draggable="true">ist</span><span class="draggable" draggable="true">Die</span><span class="draggable" draggable="true">herrscht</span><span class="draggable" draggable="true">verbannt</span><span class="draggable" draggable="true">LÜGE</span><span class="draggable" draggable="true">WAHRHEIT</span></div>
+                    <div class="drop-zone" data-correct="Die WAHRHEIT ist verbannt die LÜGE herrscht">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1149,7 +1591,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_2_emotionen/04_Gnev_A2.html
+++ b/output/a2/gruppe_2_emotionen/04_Gnev_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 4: ГНЕВ - ЯРОСТЬ ЛИРА</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -861,7 +862,424 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="греметь">
+                    <span class="word-main">donnern</span>
+                    <small class="word-hint">[ДОН-нерн]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="проклинать">
+                    <span class="word-main">fluchen</span>
+                    <small class="word-hint">[ФЛУ-хен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="взрываться">
+                    <span class="word-main">explodieren</span>
+                    <small class="word-hint">[екс-пло-ДИ-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="ярость">
+                    <span class="word-main">die Wut</span>
+                    <small class="word-hint">[ди ВУТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="бушевать">
+                    <span class="word-main">toben</span>
+                    <small class="word-hint">[ТО-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="свирепый">
+                    <span class="word-main">grimmig</span>
+                    <small class="word-hint">[ГРИМ-миг]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="неистовствовать">
+                    <span class="word-main">rasen</span>
+                    <small class="word-hint">[РА-зен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="яростный">
+                    <span class="word-main">wütend</span>
+                    <small class="word-hint">[ВЮ-тенд]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="проклинать">
+                    проклинать
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="неистовствовать">
+                    неистовствовать
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="свирепый">
+                    свирепый
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="бушевать">
+                    бушевать
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="ярость">
+                    ярость
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="греметь">
+                    греметь
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="взрываться">
+                    взрываться
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="яростный">
+                    яростный
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Wut</span>
+                        <small>ярость</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Rache</span>
+                        <small>месть</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Zorn</span>
+                        <small>гнев</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>fluchen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>проклинать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>взрываться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>яростный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>греметь</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>toben</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>взрываться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>гневаться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>проклинать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>бушевать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>donnern</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>ярость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>проклинать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>греметь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>неистовствовать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>rasen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>гореть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>бушевать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>месть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>неистовствовать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>brennen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>бушевать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>ярость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>гореть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>неистовствовать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Mein _____ brennt!</p>
+                    <p class="context-hint">Подсказка: Мой ГНЕВ пылает!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Zorn">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich bin _____!</p>
+                    <p class="context-hint">Подсказка: Я ЯРОСТЕН!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="wütend">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Die _____ verzehrt mich!</p>
+                    <p class="context-hint">Подсказка: ЯРОСТЬ пожирает меня!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Wut">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Мой ГНЕВ пробуждается</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Mein</span><span class="draggable" draggable="true">ZORN</span><span class="draggable" draggable="true">erwacht</span></div>
+                    <div class="drop-zone" data-correct="Mein ZORN erwacht">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Как ты смеешь</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">es</span><span class="draggable" draggable="true">kannst</span><span class="draggable" draggable="true">wagen</span><span class="draggable" draggable="true">Wie</span><span class="draggable" draggable="true">du</span></div>
+                    <div class="drop-zone" data-correct="Wie kannst du es wagen">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1149,7 +1567,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_2_emotionen/05_Strah_A2.html
+++ b/output/a2/gruppe_2_emotionen/05_Strah_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 5: СТРАХ - УЖАС В НОЧИ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -861,7 +862,448 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="жестокий">
+                    <span class="word-main">grausam</span>
+                    <small class="word-hint">[ГРАУ-зам]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="дрожать">
+                    <span class="word-main">zittern</span>
+                    <small class="word-hint">[ЦИТ-терн]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="боязнь">
+                    <span class="word-main">die Furcht</span>
+                    <small class="word-hint">[ди ФУРХТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="тревожиться">
+                    <span class="word-main">bangen</span>
+                    <small class="word-hint">[БАН-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="содрогаться">
+                    <span class="word-main">schaudern</span>
+                    <small class="word-hint">[ШАУ-дерн]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="бояться">
+                    <span class="word-main">fürchten</span>
+                    <small class="word-hint">[ФЮРХ-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="страх">
+                    <span class="word-main">die Angst</span>
+                    <small class="word-hint">[ди АНГСТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="паника">
+                    <span class="word-main">die Panik</span>
+                    <small class="word-hint">[ди ПА-ник]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="дрожать">
+                    дрожать
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="паника">
+                    паника
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="бояться">
+                    бояться
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="тревожиться">
+                    тревожиться
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="страх">
+                    страх
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="боязнь">
+                    боязнь
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="жестокий">
+                    жестокий
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="содрогаться">
+                    содрогаться
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Schrecken</span>
+                        <small>ужас</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Furcht</span>
+                        <small>боязнь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Panik</span>
+                        <small>паника</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Angst</span>
+                        <small>страх</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Grauen</span>
+                        <small>кошмар</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>die Furcht</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>дрожать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>пугать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>боязнь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>боязливый</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>das Grauen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>кошмар</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>дрожать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>паника</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>жестокий</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>die Angst</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>страх</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>пугать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>боязнь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>бояться</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>ängstlich</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>содрогаться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>боязливый</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>ужас</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>кошмар</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>grausam</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>ужас</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>страх</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>содрогаться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>жестокий</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Die _____ kommt!</p>
+                    <p class="context-hint">Подсказка: СТРАХ приходит!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Angst">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ der Nacht!</p>
+                    <p class="context-hint">Подсказка: УЖАС ночи!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Schrecken">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Welches _____!</p>
+                    <p class="context-hint">Подсказка: Какой КОШМАР!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Grauen">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">СТРАХ вползает в моё сердце</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">mein</span><span class="draggable" draggable="true">kriecht</span><span class="draggable" draggable="true">Herz</span><span class="draggable" draggable="true">Die</span><span class="draggable" draggable="true">in</span><span class="draggable" draggable="true">ANGST</span></div>
+                    <div class="drop-zone" data-correct="Die ANGST kriecht in mein Herz">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я БОЮСЬ сойти с ума</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">zu</span><span class="draggable" draggable="true">werden</span><span class="draggable" draggable="true">verrückt</span><span class="draggable" draggable="true">FÜRCHTE</span><span class="draggable" draggable="true">Ich</span></div>
+                    <div class="drop-zone" data-correct="Ich FÜRCHTE verrückt zu werden">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1149,7 +1591,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_2_emotionen/06_Lyubov_A2.html
+++ b/output/a2/gruppe_2_emotionen/06_Lyubov_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 Сцена 6: Любовь в трагедии</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -854,7 +855,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="верность">
+                    <span class="word-main">die Treue</span>
+                    <small class="word-hint">[ди ТРОЙ-е]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="страсть">
+                    <span class="word-main">die Leidenschaft</span>
+                    <small class="word-hint">[ди ЛАЙ-ден-шафт]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="прощать">
+                    <span class="word-main">verzeihen</span>
+                    <small class="word-hint">[фер-ЦАЙ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="любовь">
+                    <span class="word-main">die Liebe</span>
+                    <small class="word-hint">[ди ЛИ-бе]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="поцелуй">
+                    <span class="word-main">der Kuss</span>
+                    <small class="word-hint">[дер КУС]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="ревность">
+                    <span class="word-main">die Eifersucht</span>
+                    <small class="word-hint">[ди АЙ-фер-зухт]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="любить">
+                    <span class="word-main">lieben</span>
+                    <small class="word-hint">[ЛИ-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="выходить замуж">
+                    <span class="word-main">heiraten</span>
+                    <small class="word-hint">[ХАЙ-ра-тен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="прощать">
+                    прощать
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="поцелуй">
+                    поцелуй
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="любить">
+                    любить
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="выходить замуж">
+                    выходить замуж
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="ревность">
+                    ревность
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="верность">
+                    верность
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="страсть">
+                    страсть
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="любовь">
+                    любовь
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Herz</span>
+                        <small>сердце</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Kuss</span>
+                        <small>поцелуй</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Liebe</span>
+                        <small>любовь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Leidenschaft</span>
+                        <small>страсть</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Treue</span>
+                        <small>верность</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Eifersucht</span>
+                        <small>ревность</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>verlassen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>выходить замуж</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>покидать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>любовь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>любить</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>das Herz</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>нежный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>прощать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>верность</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>сердце</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>die Liebe</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>любовь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>нежный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>прощать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>поцелуй</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Treue</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>ревность</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>верность</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>любить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>поцелуй</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>verzeihen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>нежный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>прощать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>выходить замуж</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>верность</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Die wahre _____ spricht nicht viel</p>
+                    <p class="context-hint">Подсказка: Истинная любовь не многословна</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Liebe">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Mein _____ bricht!</p>
+                    <p class="context-hint">Подсказка: Моё сердце разрывается!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Herz">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ein _____ des Verrats</p>
+                    <p class="context-hint">Подсказка: Поцелуй предательства</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Kuss">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Которая из вас ЛЮБИТ меня больше всех</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">mich</span><span class="draggable" draggable="true">von</span><span class="draggable" draggable="true">meisten</span><span class="draggable" draggable="true">LIEBT</span><span class="draggable" draggable="true">euch</span><span class="draggable" draggable="true">am</span><span class="draggable" draggable="true">Welche</span></div>
+                    <div class="drop-zone" data-correct="Welche von euch LIEBT mich am meisten">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Говорите от СЕРДЦА</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">aus</span><span class="draggable" draggable="true">HERZEN</span><span class="draggable" draggable="true">eurem</span><span class="draggable" draggable="true">Sprecht</span></div>
+                    <div class="drop-zone" data-correct="Sprecht aus eurem HERZEN">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1142,7 +1596,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_3_handlungen/07_Puteshestvie_A2.html
+++ b/output/a2/gruppe_3_handlungen/07_Puteshestvie_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 7: ПУТЕШЕСТВИЕ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -852,7 +853,448 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="бежать">
+                    <span class="word-main">fliehen</span>
+                    <small class="word-hint">[ФЛИ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="путешествие">
+                    <span class="word-main">die Reise</span>
+                    <small class="word-hint">[ди РАЙ-зе]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="скитаться">
+                    <span class="word-main">wandern</span>
+                    <small class="word-hint">[ВАН-дерн]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="побег">
+                    <span class="word-main">die Flucht</span>
+                    <small class="word-hint">[ди ФЛУХТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="покидать">
+                    <span class="word-main">verlassen</span>
+                    <small class="word-hint">[фер-ЛА-сен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="путь">
+                    <span class="word-main">der Weg</span>
+                    <small class="word-hint">[дер ВЕГ]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="прибывать">
+                    <span class="word-main">ankommen</span>
+                    <small class="word-hint">[АН-ком-мен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="родина">
+                    <span class="word-main">die Heimat</span>
+                    <small class="word-hint">[ди ХАЙ-мат]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="путь">
+                    путь
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="родина">
+                    родина
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="побег">
+                    побег
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="покидать">
+                    покидать
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="прибывать">
+                    прибывать
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="скитаться">
+                    скитаться
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="бежать">
+                    бежать
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="путешествие">
+                    путешествие
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Flucht</span>
+                        <small>побег</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Sturm</span>
+                        <small>буря</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Reise</span>
+                        <small>путешествие</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Heimat</span>
+                        <small>родина</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Weg</span>
+                        <small>путь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>der Sturm</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>бежать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>побег</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>путешествие</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>буря</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>gehen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>бежать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>путешествие</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>покидать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>идти</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>fliehen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>идти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>возвращаться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>путь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>бежать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>zurückkehren</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>искать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>родина</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>возвращаться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>путь</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>der Weg</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>буря</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>побег</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>путь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>путешествие</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Eine _____ durch Wahnsinn und Sturm</p>
+                    <p class="context-hint">Подсказка: Путешествие через безумие и бурю</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Reise">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ zu den Klippen von Dover</p>
+                    <p class="context-hint">Подсказка: Путь к утёсам Дувра</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Weg">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Wohin soll ich _____?</p>
+                    <p class="context-hint">Подсказка: Куда мне идти?</p>
+                    <input type="text" placeholder="Введите слово" data-correct="gehen">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Куда ведёт мой ПУТЬ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Wohin</span><span class="draggable" draggable="true">mein</span><span class="draggable" draggable="true">führt</span><span class="draggable" draggable="true">WEG</span></div>
+                    <div class="drop-zone" data-correct="Wohin führt mein WEG">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я должен ИДТИ, но не знаю куда</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">aber</span><span class="draggable" draggable="true">weiß</span><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">wohin</span><span class="draggable" draggable="true">GEHEN</span><span class="draggable" draggable="true">nicht</span><span class="draggable" draggable="true">muss</span></div>
+                    <div class="drop-zone" data-correct="Ich muss GEHEN aber ich weiß nicht wohin">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1140,7 +1582,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_3_handlungen/08_Poisk_A2.html
+++ b/output/a2/gruppe_3_handlungen/08_Poisk_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 8: ПОИСК</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -852,7 +853,412 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="поиск">
+                    <span class="word-main">die Suche</span>
+                    <small class="word-hint">[ди ЗУ-хе]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="след">
+                    <span class="word-main">die Spur</span>
+                    <small class="word-hint">[ди ШПУР]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="находить">
+                    <span class="word-main">finden</span>
+                    <small class="word-hint">[ФИН-ден]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="узнавать">
+                    <span class="word-main">erkennen</span>
+                    <small class="word-hint">[ер-КЕН-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="встречать">
+                    <span class="word-main">begegnen</span>
+                    <small class="word-hint">[бе-ГЕГ-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="терять">
+                    <span class="word-main">verlieren</span>
+                    <small class="word-hint">[фер-ЛИ-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="искать">
+                    <span class="word-main">suchen</span>
+                    <small class="word-hint">[ЗУ-хен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="скучать, недоставать">
+                    <span class="word-main">vermissen</span>
+                    <small class="word-hint">[фер-МИ-сен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="находить">
+                    находить
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="узнавать">
+                    узнавать
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="встречать">
+                    встречать
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="искать">
+                    искать
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="след">
+                    след
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="скучать, недоставать">
+                    скучать, недоставать
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="терять">
+                    терять
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="поиск">
+                    поиск
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Suche</span>
+                        <small>поиск</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Spur</span>
+                        <small>след</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>verschwinden</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>находить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>терять</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>выслеживать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>исчезать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>vermissen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>скучать, недоставать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>терять</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>след</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>искать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>finden</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>исчезать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>находить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>поиск</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>обнаруживать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>begegnen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>искать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>встречать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>исчезать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>след</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>entdecken</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>след</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>обнаруживать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>узнавать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>находить</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Die _____ nach der Wahrheit</p>
+                    <p class="context-hint">Подсказка: Поиск правды</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Suche">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich muss mich _____</p>
+                    <p class="context-hint">Подсказка: Я должен прятаться</p>
+                    <input type="text" placeholder="Введите слово" data-correct="verstecken">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich folge seiner _____</p>
+                    <p class="context-hint">Подсказка: Я иду по его следу</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Spur">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я ИЩУ короля</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">König</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">SUCHE</span><span class="draggable" draggable="true">den</span></div>
+                    <div class="drop-zone" data-correct="Ich SUCHE den König">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Где мне его НАЙТИ в этой буре</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">FINDEN</span><span class="draggable" draggable="true">diesem</span><span class="draggable" draggable="true">Sturm</span><span class="draggable" draggable="true">kann</span><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">Wo</span><span class="draggable" draggable="true">ihn</span><span class="draggable" draggable="true">in</span></div>
+                    <div class="drop-zone" data-correct="Wo kann ich ihn FINDEN in diesem Sturm">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1140,7 +1546,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_3_handlungen/09_Pisma_A2.html
+++ b/output/a2/gruppe_3_handlungen/09_Pisma_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 9: ПИСЬМА - ИНТРИГИ И ПОСЛАНИЯ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -853,7 +854,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="перо">
+                    <span class="word-main">die Feder</span>
+                    <small class="word-hint">[ди ФЕ-дер]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="послание">
+                    <span class="word-main">die Botschaft</span>
+                    <small class="word-hint">[ди БОТ-шафт]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="сообщение">
+                    <span class="word-main">die Nachricht</span>
+                    <small class="word-hint">[ди НАХ-рихт]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="предавать, выдавать">
+                    <span class="word-main">verraten</span>
+                    <small class="word-hint">[фер-РА-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="подписывать">
+                    <span class="word-main">unterschreiben</span>
+                    <small class="word-hint">[ун-тер-ШРАЙ-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="письмо">
+                    <span class="word-main">der Brief</span>
+                    <small class="word-hint">[дер БРИФ]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="тайна">
+                    <span class="word-main">das Geheimnis</span>
+                    <small class="word-hint">[дас ге-ХАЙМ-нис]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="чернила">
+                    <span class="word-main">die Tinte</span>
+                    <small class="word-hint">[ди ТИН-те]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="тайна">
+                    тайна
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="подписывать">
+                    подписывать
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="перо">
+                    перо
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="предавать, выдавать">
+                    предавать, выдавать
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="послание">
+                    послание
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="письмо">
+                    письмо
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="чернила">
+                    чернила
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="сообщение">
+                    сообщение
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Nachricht</span>
+                        <small>сообщение</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Botschaft</span>
+                        <small>послание</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Geheimnis</span>
+                        <small>тайна</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Tinte</span>
+                        <small>чернила</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Feder</span>
+                        <small>перо</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Brief</span>
+                        <small>письмо</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>unterschreiben</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>тайна</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>сообщение</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>подписывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>послание</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>zerreißen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>разрывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>подписывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>читать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>чернила</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>versiegeln</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>письмо</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>запечатывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>сообщение</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>тайна</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Botschaft</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>писать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>послание</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>подписывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>предавать, выдавать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>lesen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>читать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>предавать, выдавать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>запечатывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>подписывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Dieser _____ wird alles ändern</p>
+                    <p class="context-hint">Подсказка: Это письмо всё изменит</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Brief">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Lass mich diesen Brief _____!</p>
+                    <p class="context-hint">Подсказка: Дай мне прочесть это письмо!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="lesen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich bringe eine _____ von der Herzogin</p>
+                    <p class="context-hint">Подсказка: Я несу сообщение от герцогини</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Nachricht">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Отец, я нашёл это ПИСЬМО</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">fand</span><span class="draggable" draggable="true">diesen</span><span class="draggable" draggable="true">BRIEF</span><span class="draggable" draggable="true">Vater</span></div>
+                    <div class="drop-zone" data-correct="Vater ich fand diesen BRIEF">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Не хотел ЧИТАТЬ, но СООБЩЕНИЕ тревожное</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">aber</span><span class="draggable" draggable="true">nicht</span><span class="draggable" draggable="true">NACHRICHT</span><span class="draggable" draggable="true">ist</span><span class="draggable" draggable="true">LESEN</span><span class="draggable" draggable="true">wollte</span><span class="draggable" draggable="true">die</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">ihn</span><span class="draggable" draggable="true">beunruhigend</span></div>
+                    <div class="drop-zone" data-correct="Ich wollte ihn nicht LESEN aber die NACHRICHT ist beunruhigend">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1141,7 +1595,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_4_orte/10_Zamok_A2.html
+++ b/output/a2/gruppe_4_orte/10_Zamok_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 10: ЗАМОК - СТЕНЫ ВЛАСТИ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -852,7 +853,496 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="окно">
+                    <span class="word-main">das Fenster</span>
+                    <small class="word-hint">[дас ФЕН-стер]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="стена">
+                    <span class="word-main">die Mauer</span>
+                    <small class="word-hint">[ди МАУ-ер]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="крепость">
+                    <span class="word-main">die Festung</span>
+                    <small class="word-hint">[ди ФЕСТ-унг]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="замок">
+                    <span class="word-main">das Schloss</span>
+                    <small class="word-hint">[дас ШЛОС]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="трон">
+                    <span class="word-main">der Thron</span>
+                    <small class="word-hint">[дер ТРОН]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="ворота">
+                    <span class="word-main">das Tor</span>
+                    <small class="word-hint">[дас ТОР]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="мост">
+                    <span class="word-main">die Brücke</span>
+                    <small class="word-hint">[ди БРЮК-ке]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="зал">
+                    <span class="word-main">der Saal</span>
+                    <small class="word-hint">[дер ЗААЛ]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="крепость">
+                    крепость
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="трон">
+                    трон
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="мост">
+                    мост
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="стена">
+                    стена
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="окно">
+                    окно
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="ворота">
+                    ворота
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="замок">
+                    замок
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="зал">
+                    зал
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Turm</span>
+                        <small>башня</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Kerker</span>
+                        <small>темница</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Mauer</span>
+                        <small>стена</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Brücke</span>
+                        <small>мост</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Kammer</span>
+                        <small>комната, покои</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Saal</span>
+                        <small>зал</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Tor</span>
+                        <small>ворота</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Festung</span>
+                        <small>крепость</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Schloss</span>
+                        <small>замок</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>der Kerker</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>замок</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>темница</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>мост</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>трон</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>das Tor</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>мост</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>ворота</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>крепость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>темница</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>die Festung</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>крепость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>мост</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>ворота</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>комната, покои</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Mauer</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>лестница</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>темница</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>замок</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>стена</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>der Thron</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>ворота</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>зал</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>мост</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>трон</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Dieses _____ gehörte mir</p>
+                    <p class="context-hint">Подсказка: Этот замок принадлежал мне</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Schloss">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Vom _____ sah ich die Armee</p>
+                    <p class="context-hint">Подсказка: С башни я увидел армию</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Turm">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">In diesem _____ teilte ich mein Reich</p>
+                    <p class="context-hint">Подсказка: В этом зале я разделил королевство</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Saal">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">В этом ЗАМКЕ, в этом ЗАЛЕ, перед моим ТРОНОМ - делю я королевство</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">SAAL</span><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">mein</span><span class="draggable" draggable="true">THRON</span><span class="draggable" draggable="true">diesem</span><span class="draggable" draggable="true">In</span><span class="draggable" draggable="true">vor</span><span class="draggable" draggable="true">meinem</span><span class="draggable" draggable="true">in</span><span class="draggable" draggable="true">teile</span><span class="draggable" draggable="true">SCHLOSS</span><span class="draggable" draggable="true">Reich</span><span class="draggable" draggable="true">diesem</span></div>
+                    <div class="drop-zone" data-correct="In diesem SCHLOSS in diesem SAAL vor meinem THRON teile ich mein Reich">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Закройте ВОРОТА</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">TORE</span><span class="draggable" draggable="true">Schließt</span><span class="draggable" draggable="true">die</span></div>
+                    <div class="drop-zone" data-correct="Schließt die TORE">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1140,7 +1630,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_4_orte/11_Les_A2.html
+++ b/output/a2/gruppe_4_orte/11_Les_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 11: ЛЕС - БУРЯ И БЕЗУМИЕ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -852,7 +853,496 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="дождь">
+                    <span class="word-main">der Regen</span>
+                    <small class="word-hint">[дер РЕ-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="хижина">
+                    <span class="word-main">die Hütte</span>
+                    <small class="word-hint">[ди ХЮТ-те]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="лес">
+                    <span class="word-main">der Wald</span>
+                    <small class="word-hint">[дер ВАЛД]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="лист">
+                    <span class="word-main">das Blatt</span>
+                    <small class="word-hint">[дас БЛАТТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="молния">
+                    <span class="word-main">der Blitz</span>
+                    <small class="word-hint">[дер БЛИЦ]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="дерево">
+                    <span class="word-main">der Baum</span>
+                    <small class="word-hint">[дер БАУМ]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="темнота">
+                    <span class="word-main">die Dunkelheit</span>
+                    <small class="word-hint">[ди ДУН-кель-хайт]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="корень">
+                    <span class="word-main">die Wurzel</span>
+                    <small class="word-hint">[ди ВУР-цель]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="корень">
+                    корень
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="лист">
+                    лист
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="дерево">
+                    дерево
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="дождь">
+                    дождь
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="лес">
+                    лес
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="темнота">
+                    темнота
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="хижина">
+                    хижина
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="молния">
+                    молния
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Hütte</span>
+                        <small>хижина</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Wind</span>
+                        <small>ветер</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Pfad</span>
+                        <small>тропа</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Regen</span>
+                        <small>дождь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Donner</span>
+                        <small>гром</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Blatt</span>
+                        <small>лист</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Wurzel</span>
+                        <small>корень</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Baum</span>
+                        <small>дерево</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Blitz</span>
+                        <small>молния</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>der Blitz</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>корень</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>ветер</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>молния</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>тропа</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>der Baum</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>дерево</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>лист</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>корень</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>лес</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>die Wurzel</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>корень</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>ветер</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>дождь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>темнота</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>der Regen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>гром</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>дождь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>лес</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>дерево</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Dunkelheit</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>буря</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>тропа</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>темнота</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>гром</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">In diesem _____ bin ich wahrhaft König</p>
+                    <p class="context-hint">Подсказка: В этом лесу я истинный король</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Wald">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Unter diesem _____ verstecke ich mich</p>
+                    <p class="context-hint">Подсказка: Под этим деревом я прячусь</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Baum">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Heule, _____! Du bist nicht so grausam wie meine Töchter!</p>
+                    <p class="context-hint">Подсказка: Вой, буря! Ты не так жестока, как мои дочери!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Sturm">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я бросаю вызов БУРЕ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">dem</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">STURM</span><span class="draggable" draggable="true">trotze</span></div>
+                    <div class="drop-zone" data-correct="Ich trotze dem STURM">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Пусть ГРОМ говорит</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">DONNER</span><span class="draggable" draggable="true">Der</span><span class="draggable" draggable="true">soll</span><span class="draggable" draggable="true">sprechen</span></div>
+                    <div class="drop-zone" data-correct="Der DONNER soll sprechen">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1140,7 +1630,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_4_orte/12_Temnitsa_A2.html
+++ b/output/a2/gruppe_4_orte/12_Temnitsa_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 12: ТЕМНИЦА</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -849,7 +850,496 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="свобода">
+                    <span class="word-main">die Freiheit</span>
+                    <small class="word-hint">[ди ФРАЙ-хайт]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="стражник">
+                    <span class="word-main">der Wächter</span>
+                    <small class="word-hint">[дер ВЕХ-тер]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="темница">
+                    <span class="word-main">das Gefängnis</span>
+                    <small class="word-hint">[дас ге-ФЕНГ-нис]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="цепи">
+                    <span class="word-main">die Ketten</span>
+                    <small class="word-hint">[ди КЕТ-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="молиться">
+                    <span class="word-main">beten</span>
+                    <small class="word-hint">[БЕ-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="стена">
+                    <span class="word-main">die Mauer</span>
+                    <small class="word-hint">[ди МАУ-ер]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="узник">
+                    <span class="word-main">der Gefangene</span>
+                    <small class="word-hint">[дер ге-ФАН-ге-не]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="замок">
+                    <span class="word-main">das Schloss</span>
+                    <small class="word-hint">[дас ШЛОС]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="стражник">
+                    стражник
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="молиться">
+                    молиться
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="стена">
+                    стена
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="замок">
+                    замок
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="цепи">
+                    цепи
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="темница">
+                    темница
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="свобода">
+                    свобода
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="узник">
+                    узник
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Dunkelheit</span>
+                        <small>темнота</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Gefängnis</span>
+                        <small>темница</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Schloss</span>
+                        <small>замок</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Freiheit</span>
+                        <small>свобода</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Ketten</span>
+                        <small>цепи</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Gefangene</span>
+                        <small>узник</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Fenster</span>
+                        <small>окно</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Mauer</span>
+                        <small>стена</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Wächter</span>
+                        <small>стражник</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>die Dunkelheit</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>темнота</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>узник</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>стражник</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>стена</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>der Gefangene</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>узник</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>молиться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>свобода</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>цепи</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>singen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>прощать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>окно</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>замок</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>петь</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>das Fenster</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>петь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>молиться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>окно</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>темнота</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>das Gefängnis</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>стражник</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>темница</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>петь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>окно</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Das _____ wird unser Paradies sein</p>
+                    <p class="context-hint">Подсказка: Темница станет нашим раем</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Gefängnis">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Diese _____ sind nichts gegen unsere Liebe</p>
+                    <p class="context-hint">Подсказка: Эти цепи ничто против нашей любви</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Ketten">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Die _____ ist in unserem Herzen</p>
+                    <p class="context-hint">Подсказка: Свобода в нашем сердце</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Freiheit">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Пойдём, идём в ТЕМНИЦУ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">gehen</span><span class="draggable" draggable="true">lass</span><span class="draggable" draggable="true">Komm</span><span class="draggable" draggable="true">uns</span><span class="draggable" draggable="true">ins</span><span class="draggable" draggable="true">GEFÄNGNIS</span></div>
+                    <div class="drop-zone" data-correct="Komm lass uns ins GEFÄNGNIS gehen">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Мы будем там ПЕТЬ как птицы</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">SINGEN</span><span class="draggable" draggable="true">werden</span><span class="draggable" draggable="true">Wir</span><span class="draggable" draggable="true">wie</span><span class="draggable" draggable="true">Vögel</span><span class="draggable" draggable="true">dort</span></div>
+                    <div class="drop-zone" data-correct="Wir werden dort SINGEN wie Vögel">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1137,7 +1627,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_5_zeit/13_Proshloe_A2.html
+++ b/output/a2/gruppe_5_zeit/13_Proshloe_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 13: ПРОШЛОЕ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -849,7 +850,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="прошлое">
+                    <span class="word-main">die Vergangenheit</span>
+                    <small class="word-hint">[ди фер-ГАН-ген-хайт]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="вспоминать">
+                    <span class="word-main">erinnern</span>
+                    <small class="word-hint">[е-РИН-нерн]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="сожалеть">
+                    <span class="word-main">bereuen</span>
+                    <small class="word-hint">[бе-РОЙ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="молодость">
+                    <span class="word-main">die Jugend</span>
+                    <small class="word-hint">[ди Ю-генд]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="ошибка">
+                    <span class="word-main">der Fehler</span>
+                    <small class="word-hint">[дер ФЕ-лер]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="раньше">
+                    <span class="word-main">früher</span>
+                    <small class="word-hint">[ФРЮ-ер]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="забывать">
+                    <span class="word-main">vergessen</span>
+                    <small class="word-hint">[фер-ГЕ-сен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="время">
+                    <span class="word-main">die Zeit</span>
+                    <small class="word-hint">[ди ЦАЙТ]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="забывать">
+                    забывать
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="время">
+                    время
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="молодость">
+                    молодость
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="раньше">
+                    раньше
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="вспоминать">
+                    вспоминать
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="ошибка">
+                    ошибка
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="прошлое">
+                    прошлое
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="сожалеть">
+                    сожалеть
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Vergangenheit</span>
+                        <small>прошлое</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Erinnerung</span>
+                        <small>воспоминание</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Jugend</span>
+                        <small>молодость</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Alter</span>
+                        <small>старость</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Zeit</span>
+                        <small>время</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Fehler</span>
+                        <small>ошибка</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>die Vergangenheit</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>сожалеть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>воспоминание</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>прошлое</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>старость</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>einst</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>воспоминание</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>вспоминать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>когда-то</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>молодость</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>der Fehler</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>ошибка</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>вспоминать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>молодость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>старость</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>früher</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>раньше</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>воспоминание</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>сожалеть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>забывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Erinnerung</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>старость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>сожалеть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>воспоминание</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>раньше</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Die _____ verfolgt mich</p>
+                    <p class="context-hint">Подсказка: Прошлое преследует меня</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Vergangenheit">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Die _____ an bessere Zeiten</p>
+                    <p class="context-hint">Подсказка: Воспоминание о лучших временах</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Erinnerung">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Mein größter _____ war Stolz</p>
+                    <p class="context-hint">Подсказка: Моя главная ошибка была гордыня</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Fehler">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я вижу свою ОШИБКУ - я был слеп</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">war</span><span class="draggable" draggable="true">FEHLER</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">blind</span><span class="draggable" draggable="true">meinen</span><span class="draggable" draggable="true">sehe</span></div>
+                    <div class="drop-zone" data-correct="Ich sehe meinen FEHLER ich war blind">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">РАНЬШЕ у вас была корона, ТОГДА вы были королём</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">waren</span><span class="draggable" draggable="true">eine</span><span class="draggable" draggable="true">Ihr</span><span class="draggable" draggable="true">FRÜHER</span><span class="draggable" draggable="true">DAMALS</span><span class="draggable" draggable="true">Sie</span><span class="draggable" draggable="true">Krone</span><span class="draggable" draggable="true">König</span><span class="draggable" draggable="true">hattet</span></div>
+                    <div class="drop-zone" data-correct="FRÜHER Ihr hattet eine Krone DAMALS waren Sie König">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1137,7 +1591,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_5_zeit/14_Nastoyashchee_A2.html
+++ b/output/a2/gruppe_5_zeit/14_Nastoyashchee_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 14: НАСТОЯЩЕЕ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -849,7 +850,424 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="спасать">
+                    <span class="word-main">retten</span>
+                    <small class="word-hint">[РЕ-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="сейчас">
+                    <span class="word-main">jetzt</span>
+                    <small class="word-hint">[ЙЕТЦТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="побеждать">
+                    <span class="word-main">siegen</span>
+                    <small class="word-hint">[ЗИ-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="быстро">
+                    <span class="word-main">schnell</span>
+                    <small class="word-hint">[ШНЕЛЬ]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="сегодня">
+                    <span class="word-main">heute</span>
+                    <small class="word-hint">[ХОЙ-те]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="битва">
+                    <span class="word-main">der Kampf</span>
+                    <small class="word-hint">[дер КАМПФ]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="немедленно">
+                    <span class="word-main">sofort</span>
+                    <small class="word-hint">[зо-ФОРТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="падать">
+                    <span class="word-main">fallen</span>
+                    <small class="word-hint">[ФА-лен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="битва">
+                    битва
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="сегодня">
+                    сегодня
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="сейчас">
+                    сейчас
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="падать">
+                    падать
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="спасать">
+                    спасать
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="быстро">
+                    быстро
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="побеждать">
+                    побеждать
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="немедленно">
+                    немедленно
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Schwert</span>
+                        <small>меч</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Kampf</span>
+                        <small>битва</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Moment</span>
+                        <small>момент</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>schnell</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>битва</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>немедленно</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>быстро</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>сражаться</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>das Schwert</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>меч</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>умирать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>побеждать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>сражаться</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>der Kampf</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>побеждать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>сражаться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>битва</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>сегодня</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>sofort</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>спасать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>сейчас</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>момент</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>немедленно</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>der Moment</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>спасать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>сегодня</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>момент</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>быстро</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">_____ ist die Zeit für Gerechtigkeit!</p>
+                    <p class="context-hint">Подсказка: Сейчас время для справедливости!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="jetzt">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">_____ entscheidet sich alles!</p>
+                    <p class="context-hint">Подсказка: Сегодня всё решится!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="heute">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ der Wahrheit ist gekommen</p>
+                    <p class="context-hint">Подсказка: Момент истины настал</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Moment">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">СЕЙЧАС время</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">die</span><span class="draggable" draggable="true">ist</span><span class="draggable" draggable="true">JETZT</span><span class="draggable" draggable="true">Zeit</span></div>
+                    <div class="drop-zone" data-correct="JETZT ist die Zeit">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я вызываю тебя на БИТВУ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">zum</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">fordere</span><span class="draggable" draggable="true">dich</span><span class="draggable" draggable="true">KAMPF</span></div>
+                    <div class="drop-zone" data-correct="Ich fordere dich zum KAMPF">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1137,7 +1555,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/a2/gruppe_5_zeit/15_Budushchee_A2.html
+++ b/output/a2/gruppe_5_zeit/15_Budushchee_A2.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>📚 СЦЕНА 15: БУДУЩЕЕ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -849,7 +850,448 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="будущее">
+                    <span class="word-main">die Zukunft</span>
+                    <small class="word-hint">[ди ЦУ-кунфт]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="жить дальше">
+                    <span class="word-main">weiterleben</span>
+                    <small class="word-hint">[ВАЙ-тер-ле-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="становиться">
+                    <span class="word-main">werden</span>
+                    <small class="word-hint">[ВЕР-ден]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="начало">
+                    <span class="word-main">der Anfang</span>
+                    <small class="word-hint">[дер АН-фанг]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="надеяться">
+                    <span class="word-main">hoffen</span>
+                    <small class="word-hint">[ХО-фен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="планировать">
+                    <span class="word-main">planen</span>
+                    <small class="word-hint">[ПЛА-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="вечно">
+                    <span class="word-main">ewig</span>
+                    <small class="word-hint">[Е-виг]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="судьба">
+                    <span class="word-main">das Schicksal</span>
+                    <small class="word-hint">[дас ШИК-заль]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="вечно">
+                    вечно
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="становиться">
+                    становиться
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="будущее">
+                    будущее
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="судьба">
+                    судьба
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="планировать">
+                    планировать
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="начало">
+                    начало
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="надеяться">
+                    надеяться
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="жить дальше">
+                    жить дальше
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Schicksal</span>
+                        <small>судьба</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Zukunft</span>
+                        <small>будущее</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Anfang</span>
+                        <small>начало</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Hoffnung</span>
+                        <small>надежда</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Ende</span>
+                        <small>конец</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>hoffen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>надежда</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>никогда</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>будущее</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>надеяться</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>die Hoffnung</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>надежда</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>никогда</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>конец</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>планировать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>weiterleben</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>жить дальше</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>судьба</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>конец</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>становиться</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>niemals</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>никогда</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>завтра</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>начало</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>становиться</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>morgen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>планировать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>завтра</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>конец</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>вечно</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Die _____ liegt in unseren Händen</p>
+                    <p class="context-hint">Подсказка: Будущее в наших руках</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Zukunft">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">_____ werden wir zusammen sein</p>
+                    <p class="context-hint">Подсказка: Завтра мы будем вместе</p>
+                    <input type="text" placeholder="Введите слово" data-correct="morgen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich werde König _____!</p>
+                    <p class="context-hint">Подсказка: Я стану королём!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="werden">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">БУДУЩЕЕ королевства - мы должны СТАТЬ новыми</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">müssen</span><span class="draggable" draggable="true">Die</span><span class="draggable" draggable="true">des</span><span class="draggable" draggable="true">ZUKUNFT</span><span class="draggable" draggable="true">Königreichs</span><span class="draggable" draggable="true">wir</span><span class="draggable" draggable="true">WERDEN</span><span class="draggable" draggable="true">neu</span></div>
+                    <div class="drop-zone" data-correct="Die ZUKUNFT des Königreichs wir müssen neu WERDEN">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">ЗАВТРА мы будем свободны, я НАДЕЮСЬ на это</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">frei</span><span class="draggable" draggable="true">werden</span><span class="draggable" draggable="true">wir</span><span class="draggable" draggable="true">HOFFE</span><span class="draggable" draggable="true">sein</span><span class="draggable" draggable="true">darauf</span><span class="draggable" draggable="true">MORGEN</span></div>
+                    <div class="drop-zone" data-correct="MORGEN werden wir frei sein ich HOFFE darauf">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1137,7 +1579,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_1_hof/01_Tronnyy_zal_B1.html
+++ b/output/b1/gruppe_1_hof/01_Tronnyy_zal_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 АКТ I, СЦЕНА 1: ТРОННЫЙ ЗАЛ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -860,7 +861,472 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="торжественный">
+                    <span class="word-main">feierlich</span>
+                    <small class="word-hint">[ФАЙ-ер-лих]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="власть">
+                    <span class="word-main">die Macht</span>
+                    <small class="word-hint">[ди МАХТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="великолепный">
+                    <span class="word-main">prächtig</span>
+                    <small class="word-hint">[ПРЕХ-тиг]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="править">
+                    <span class="word-main">herrschen</span>
+                    <small class="word-hint">[ХЕР-шен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="королевство">
+                    <span class="word-main">das Königreich</span>
+                    <small class="word-hint">[дас КЁ-ниг-райх]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="корона">
+                    <span class="word-main">die Krone</span>
+                    <small class="word-hint">[ди КРО-не]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="повиноваться">
+                    <span class="word-main">gehorchen</span>
+                    <small class="word-hint">[ге-ХОР-хен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="церемония">
+                    <span class="word-main">die Zeremonie</span>
+                    <small class="word-hint">[ди це-ре-мо-НИ]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="корона">
+                    корона
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="торжественный">
+                    торжественный
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="власть">
+                    власть
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="королевство">
+                    королевство
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="править">
+                    править
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="повиноваться">
+                    повиноваться
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="великолепный">
+                    великолепный
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="церемония">
+                    церемония
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Zeremonie</span>
+                        <small>церемония</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Adel</span>
+                        <small>знать</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Krone</span>
+                        <small>корона</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Hof</span>
+                        <small>двор</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Macht</span>
+                        <small>власть</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Königreich</span>
+                        <small>королевство</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Thron</span>
+                        <small>трон</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>die Zeremonie</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>церемония</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>торжественный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>знать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>повиноваться</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>verkünden</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>королевство</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>повиноваться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>корона</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>провозглашать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>herrschen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>повиноваться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>церемония</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>знать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>править</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>feierlich</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>корона</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>править</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>торжественный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>знать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Krone</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>торжественный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>великолепный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>корона</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>провозглашать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Vom _____ herab verkünde ich!</p>
+                    <p class="context-hint">Подсказка: С ТРОНА возвещаю!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Thron">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Mein _____ teile ich!</p>
+                    <p class="context-hint">Подсказка: Моё КОРОЛЕВСТВО делю!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Königreich">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Diese _____ ist schwer!</p>
+                    <p class="context-hint">Подсказка: Эта КОРОНА тяжела!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Krone">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">С ТРОНА ПРОВОЗГЛАШАЮ - наше КОРОЛЕВСТВО сегодня будет разделено</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">KÖNIGREICH</span><span class="draggable" draggable="true">wird</span><span class="draggable" draggable="true">geteilt</span><span class="draggable" draggable="true">herab</span><span class="draggable" draggable="true">unser</span><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">heute</span><span class="draggable" draggable="true">VERKÜNDE</span><span class="draggable" draggable="true">THRON</span><span class="draggable" draggable="true">Vom</span></div>
+                    <div class="drop-zone" data-correct="Vom THRON herab VERKÜNDE ich unser KÖNIGREICH wird heute geteilt">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">ДВОР собрался</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">ist</span><span class="draggable" draggable="true">HOF</span><span class="draggable" draggable="true">Der</span><span class="draggable" draggable="true">versammelt</span></div>
+                    <div class="drop-zone" data-correct="Der HOF ist versammelt">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1148,7 +1614,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_1_hof/02_Ispytanie_lyubvi_B1.html
+++ b/output/b1/gruppe_1_hof/02_Ispytanie_lyubvi_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 АКТ I, СЦЕНА 2: ИСПЫТАНИЕ ЛЮБВИ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -849,7 +850,436 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="понимать">
+                    <span class="word-main">verstehen</span>
+                    <small class="word-hint">[фер-ШТЕ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="ложь">
+                    <span class="word-main">die Lüge</span>
+                    <small class="word-hint">[ди ЛЮ-ге]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="клясться">
+                    <span class="word-main">schwören</span>
+                    <small class="word-hint">[ШВЁ-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="любить">
+                    <span class="word-main">lieben</span>
+                    <small class="word-hint">[ЛИ-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="разочаровывать">
+                    <span class="word-main">enttäuschen</span>
+                    <small class="word-hint">[ент-ТОЙ-шен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="делить">
+                    <span class="word-main">teilen</span>
+                    <small class="word-hint">[ТАЙ-лен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="молчать">
+                    <span class="word-main">schweigen</span>
+                    <small class="word-hint">[ШВАЙ-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="доказывать">
+                    <span class="word-main">beweisen</span>
+                    <small class="word-hint">[бе-ВАЙ-зен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="разочаровывать">
+                    разочаровывать
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="делить">
+                    делить
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="понимать">
+                    понимать
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="ложь">
+                    ложь
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="клясться">
+                    клясться
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="доказывать">
+                    доказывать
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="любить">
+                    любить
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="молчать">
+                    молчать
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Prüfung</span>
+                        <small>испытание</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Wahrheit</span>
+                        <small>правда</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Lüge</span>
+                        <small>ложь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Erbe</span>
+                        <small>наследство</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>enttäuschen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>понимать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>ложь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>любить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>разочаровывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>die Lüge</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>говорить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>ложь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>делить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>любить</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>sprechen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>говорить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>испытание</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>наследство</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>правда</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>teilen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>ложь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>разочаровывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>доказывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>делить</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>verstehen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>разочаровывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>понимать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>доказывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>делить</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Die _____ meiner Töchter beginnt!</p>
+                    <p class="context-hint">Подсказка: Испытание моих дочерей начинается!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Prüfung">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich kann nicht so _____ wie meine Schwestern</p>
+                    <p class="context-hint">Подсказка: Я не могу говорить как мои сёстры</p>
+                    <input type="text" placeholder="Введите слово" data-correct="sprechen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich sage nur die _____</p>
+                    <p class="context-hint">Подсказка: Я говорю только правду</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Wahrheit">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">ИСПЫТАНИЕ начинается</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">PRÜFUNG</span><span class="draggable" draggable="true">beginnt</span><span class="draggable" draggable="true">Die</span></div>
+                    <div class="drop-zone" data-correct="Die PRÜFUNG beginnt">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Кто хочет ДЕЛИТЬ моё НАСЛЕДСТВО</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">will</span><span class="draggable" draggable="true">ERBE</span><span class="draggable" draggable="true">mein</span><span class="draggable" draggable="true">TEILEN</span><span class="draggable" draggable="true">Wer</span></div>
+                    <div class="drop-zone" data-correct="Wer will mein ERBE TEILEN">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1137,7 +1567,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_1_hof/03_Izgnanie_Kordelii_B1.html
+++ b/output/b1/gruppe_1_hof/03_Izgnanie_Kordelii_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 АКТ I, СЦЕНА 3: ИЗГНАНИЕ КОРДЕЛИИ</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -849,7 +850,424 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="приданое">
+                    <span class="word-main">die Mitgift</span>
+                    <small class="word-hint">[ди МИТ-гифт]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="изгонять">
+                    <span class="word-main">verstoßen</span>
+                    <small class="word-hint">[фер-ШТО-сен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="изгнать">
+                    <span class="word-main">verbannen</span>
+                    <small class="word-hint">[фер-БАН-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="покидать">
+                    <span class="word-main">verlassen</span>
+                    <small class="word-hint">[фер-ЛА-сен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="наказание">
+                    <span class="word-main">die Strafe</span>
+                    <small class="word-hint">[ди ШТРА-фе]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="ничто">
+                    <span class="word-main">nichts</span>
+                    <small class="word-hint">[НИХТС]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="проклинать">
+                    <span class="word-main">verfluchen</span>
+                    <small class="word-hint">[фер-ФЛУ-хен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="принимать">
+                    <span class="word-main">aufnehmen</span>
+                    <small class="word-hint">[АУФ-не-мен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="приданое">
+                    приданое
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="покидать">
+                    покидать
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="ничто">
+                    ничто
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="изгнать">
+                    изгнать
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="принимать">
+                    принимать
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="изгонять">
+                    изгонять
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="наказание">
+                    наказание
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="проклинать">
+                    проклинать
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Zorn</span>
+                        <small>гнев</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Strafe</span>
+                        <small>наказание</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Mitgift</span>
+                        <small>приданое</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>der Zorn</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>гнев</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>проклинать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>принимать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>изгонять</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>nichts</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>ничто</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>изгонять</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>изгнать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>покидать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>aufnehmen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>принимать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>сожалеть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>проклинать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>приданое</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>verlassen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>покидать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>гнев</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>защищать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>ничто</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>verfluchen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>защищать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>проклинать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>принимать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>ничто</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Mein _____ ist grenzenlos!</p>
+                    <p class="context-hint">Подсказка: Мой гнев безграничен!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Zorn">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">_____, mein Herr</p>
+                    <p class="context-hint">Подсказка: Ничего, мой господин</p>
+                    <input type="text" placeholder="Введите слово" data-correct="nichts">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich muss das Königreich _____</p>
+                    <p class="context-hint">Подсказка: Я должна покинуть королевство</p>
+                    <input type="text" placeholder="Введите слово" data-correct="verlassen">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Из ничего не выйдет НИЧЕГО</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">wird</span><span class="draggable" draggable="true">nichts</span><span class="draggable" draggable="true">NICHTS</span><span class="draggable" draggable="true">Aus</span></div>
+                    <div class="drop-zone" data-correct="Aus nichts wird NICHTS">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я не могу лгать</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">lügen</span><span class="draggable" draggable="true">kann</span><span class="draggable" draggable="true">nicht</span><span class="draggable" draggable="true">Ich</span></div>
+                    <div class="drop-zone" data-correct="Ich kann nicht lügen">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1137,7 +1555,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_2_verrat/04_Intriga_Edmunda_B1.html
+++ b/output/b1/gruppe_2_verrat/04_Intriga_Edmunda_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 АКТ II, СЦЕНА 1: ИНТРИГА ЭДМУНДА</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -849,7 +850,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="брат">
+                    <span class="word-main">der Bruder</span>
+                    <small class="word-hint">[дер БРУ-дер]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="интрига">
+                    <span class="word-main">die Intrige</span>
+                    <small class="word-hint">[ди ин-ТРИ-ге]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="бастард">
+                    <span class="word-main">der Bastard</span>
+                    <small class="word-hint">[дер БАС-тард]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="предавать">
+                    <span class="word-main">verraten</span>
+                    <small class="word-hint">[фер-РА-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="обманывать">
+                    <span class="word-main">täuschen</span>
+                    <small class="word-hint">[ТОЙ-шен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="письмо">
+                    <span class="word-main">der Brief</span>
+                    <small class="word-hint">[дер БРИФ]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="подделывать">
+                    <span class="word-main">fälschen</span>
+                    <small class="word-hint">[ФЕЛЬ-шен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="верить">
+                    <span class="word-main">glauben</span>
+                    <small class="word-hint">[ГЛАУ-бен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="письмо">
+                    письмо
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="верить">
+                    верить
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="обманывать">
+                    обманывать
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="интрига">
+                    интрига
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="брат">
+                    брат
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="подделывать">
+                    подделывать
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="бастард">
+                    бастард
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="предавать">
+                    предавать
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Intrige</span>
+                        <small>интрига</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Bastard</span>
+                        <small>бастард</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Brief</span>
+                        <small>письмо</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Bruder</span>
+                        <small>брат</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Natur</span>
+                        <small>природа</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Plan</span>
+                        <small>план</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>erben</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>верить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>интрига</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>наследовать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>обманывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>glauben</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>бастард</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>законный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>верить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>природа</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>der Plan</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>наследовать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>верить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>план</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>природа</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Natur</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>природа</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>обманывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>брат</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>верить</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>rechtmäßig</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>бастард</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>законный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>план</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>обманывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Der _____ wird siegen!</p>
+                    <p class="context-hint">Подсказка: Бастард победит!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Bastard">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Meine _____ ist perfekt!</p>
+                    <p class="context-hint">Подсказка: Моя интрига совершенна!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Intrige">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Dieser _____ beweist alles!</p>
+                    <p class="context-hint">Подсказка: Это письмо всё доказывает!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Brief">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я, БАСТАРД, победлю через ИНТРИГУ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">siegen</span><span class="draggable" draggable="true">durch</span><span class="draggable" draggable="true">werde</span><span class="draggable" draggable="true">der</span><span class="draggable" draggable="true">INTRIGE</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">BASTARD</span></div>
+                    <div class="drop-zone" data-correct="Ich der BASTARD werde durch INTRIGE siegen">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Это ПИСЬМО - я его ПОДДЕЛАЛ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">BRIEF</span><span class="draggable" draggable="true">ihn</span><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">habe</span><span class="draggable" draggable="true">GEFÄLSCHT</span><span class="draggable" draggable="true">Dieser</span></div>
+                    <div class="drop-zone" data-correct="Dieser BRIEF ich habe ihn GEFÄLSCHT">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1137,7 +1591,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_2_verrat/05_Obman_Glostera_B1.html
+++ b/output/b1/gruppe_2_verrat/05_Obman_Glostera_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 📜 Сцена 5: Обман Глостера</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -847,7 +848,448 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="ложь">
+                    <span class="word-main">die Lüge</span>
+                    <small class="word-hint">[ди ЛЮ-ге]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="верить">
+                    <span class="word-main">glauben</span>
+                    <small class="word-hint">[ГЛАУ-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="заговор">
+                    <span class="word-main">die Verschwörung</span>
+                    <small class="word-hint">[ди фер-ШВЁ-рунг]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="бастард">
+                    <span class="word-main">der Bastard</span>
+                    <small class="word-hint">[дер БАС-тард]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="предательство">
+                    <span class="word-main">der Verrat</span>
+                    <small class="word-hint">[дер фер-РАТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="бежать">
+                    <span class="word-main">fliehen</span>
+                    <small class="word-hint">[ФЛИ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="обманывать">
+                    <span class="word-main">täuschen</span>
+                    <small class="word-hint">[ТОЙ-шен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="невинный">
+                    <span class="word-main">unschuldig</span>
+                    <small class="word-hint">[ун-ШУЛЬ-диг]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="предательство">
+                    предательство
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="ложь">
+                    ложь
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="заговор">
+                    заговор
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="бежать">
+                    бежать
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="бастард">
+                    бастард
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="обманывать">
+                    обманывать
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="невинный">
+                    невинный
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="верить">
+                    верить
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Verschwörung</span>
+                        <small>заговор</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Bastard</span>
+                        <small>бастард</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Verrat</span>
+                        <small>предательство</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Brief</span>
+                        <small>письмо</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Lüge</span>
+                        <small>ложь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>die Verschwörung</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>заговор</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>слепой</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>ложь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>невинный</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>glauben</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>ложь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>бежать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>заговор</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>верить</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>die Lüge</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>невинный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>обвинять</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>ложь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>бежать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>fliehen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>бастард</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>обвинять</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>письмо</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>бежать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>täuschen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>слепой</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>подозревать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>обманывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>предательство</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Ich kann nicht _____, dass Edgar...</p>
+                    <p class="context-hint">Подсказка: Я не могу поверить, что Эдгар...</p>
+                    <input type="text" placeholder="Введите слово" data-correct="glauben">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">_____ in der eigenen Familie!</p>
+                    <p class="context-hint">Подсказка: Предательство в собственной семье!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Verrat">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Eine _____ gegen mich?</p>
+                    <p class="context-hint">Подсказка: Заговор против меня?</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Verschwörung">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Что ты прячешь</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">versteckst</span><span class="draggable" draggable="true">du</span><span class="draggable" draggable="true">Was</span><span class="draggable" draggable="true">da</span></div>
+                    <div class="drop-zone" data-correct="Was versteckst du da">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Покажи мне это ПИСЬМО</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">BRIEF</span><span class="draggable" draggable="true">mir</span><span class="draggable" draggable="true">den</span><span class="draggable" draggable="true">Zeig</span></div>
+                    <div class="drop-zone" data-correct="Zeig mir den BRIEF">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1135,7 +1577,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_2_verrat/06_Unizhenie_Lira_B1.html
+++ b/output/b1/gruppe_2_verrat/06_Unizhenie_Lira_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Сцена 6: Унижение Лира</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -847,7 +848,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="жестокость">
+                    <span class="word-main">die Grausamkeit</span>
+                    <small class="word-hint">[ди ГРАУ-зам-кайт]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="ничего">
+                    <span class="word-main">nichts</span>
+                    <small class="word-hint">[НИХТС]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="слёзы">
+                    <span class="word-main">die Tränen</span>
+                    <small class="word-hint">[ди ТРЕ-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="унижать">
+                    <span class="word-main">demütigen</span>
+                    <small class="word-hint">[ДЕ-мю-ти-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="выгонять">
+                    <span class="word-main">hinauswerfen</span>
+                    <small class="word-hint">[хин-АУС-вер-фен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="просить, умолять">
+                    <span class="word-main">betteln</span>
+                    <small class="word-hint">[БЕТ-тельн]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="неблагодарность">
+                    <span class="word-main">die Undankbarkeit</span>
+                    <small class="word-hint">[ди ун-ДАНК-бар-кайт]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="свита">
+                    <span class="word-main">das Gefolge</span>
+                    <small class="word-hint">[дас ге-ФОЛ-ге]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="унижать">
+                    унижать
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="просить, умолять">
+                    просить, умолять
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="неблагодарность">
+                    неблагодарность
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="выгонять">
+                    выгонять
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="жестокость">
+                    жестокость
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="свита">
+                    свита
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="ничего">
+                    ничего
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="слёзы">
+                    слёзы
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Grausamkeit</span>
+                        <small>жестокость</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Gefolge</span>
+                        <small>свита</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Undankbarkeit</span>
+                        <small>неблагодарность</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Würde</span>
+                        <small>достоинство</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Narr</span>
+                        <small>шут</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Tränen</span>
+                        <small>слёзы</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>verrückt</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>сумасшедший</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>слёзы</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>шут</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>просить, умолять</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>die Undankbarkeit</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>неблагодарность</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>достоинство</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>жестокость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>шут</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>der Narr</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>ничего</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>слёзы</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>жестокость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>шут</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Grausamkeit</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>свита</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>жестокость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>выгонять</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>шут</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Tränen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>просить, умолять</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>шут</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>достоинство</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>слёзы</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Diese _____ zerreißt mein Herz!</p>
+                    <p class="context-hint">Подсказка: Эта неблагодарность разрывает моё сердце!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Undankbarkeit">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Wir müssen ihn _____!</p>
+                    <p class="context-hint">Подсказка: Мы должны его унизить!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="demütigen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Wozu braucht er das _____?</p>
+                    <p class="context-hint">Подсказка: Зачем ему свита?</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Gefolge">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Зачем вам СВИТА</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Ihr</span><span class="draggable" draggable="true">das</span><span class="draggable" draggable="true">GEFOLGE</span><span class="draggable" draggable="true">Wozu</span><span class="draggable" draggable="true">braucht</span></div>
+                    <div class="drop-zone" data-correct="Wozu braucht Ihr das GEFOLGE">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Это ДОСТОИНСТВО излишне</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">überflüssig</span><span class="draggable" draggable="true">WÜRDE</span><span class="draggable" draggable="true">Diese</span><span class="draggable" draggable="true">ist</span></div>
+                    <div class="drop-zone" data-correct="Diese WÜRDE ist überflüssig">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1135,7 +1589,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_3_wahnsinn/07_Burya_i_bezumie_B1.html
+++ b/output/b1/gruppe_3_wahnsinn/07_Burya_i_bezumie_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 ⛈ Сцена 7: Буря и безумие</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -416,7 +417,7 @@ body {
                 </div>
                 <div class="word-card">
                     <div class="word-german">wahnsinnig</div>
-                    <div class="word-transcription">[ВАХН-зи-ниг]</div>
+                    <div class="word-transcription">[ВАН-зи-ниг]</div>
                     <div class="word-russian">безумный</div>
                     <div class="word-type">прилагательное</div>
                     <div class="character-voice">
@@ -847,7 +848,472 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="природа">
+                    <span class="word-main">die Natur</span>
+                    <small class="word-hint">[ди на-ТУР]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="безумный">
+                    <span class="word-main">wahnsinnig</span>
+                    <small class="word-hint">[ВАН-зи-ниг]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="молния">
+                    <span class="word-main">der Blitz</span>
+                    <small class="word-hint">[дер БЛИЦ]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="хижина">
+                    <span class="word-main">die Hütte</span>
+                    <small class="word-hint">[ди ХЮТ-те]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="дождь">
+                    <span class="word-main">der Regen</span>
+                    <small class="word-hint">[дер РЕ-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="голый, нагой">
+                    <span class="word-main">nackt</span>
+                    <small class="word-hint">[НАКТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="кричать">
+                    <span class="word-main">schreien</span>
+                    <small class="word-hint">[ШРАЙ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="мёрзнуть">
+                    <span class="word-main">frieren</span>
+                    <small class="word-hint">[ФРИ-рен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="хижина">
+                    хижина
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="дождь">
+                    дождь
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="безумный">
+                    безумный
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="кричать">
+                    кричать
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="природа">
+                    природа
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="мёрзнуть">
+                    мёрзнуть
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="молния">
+                    молния
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="голый, нагой">
+                    голый, нагой
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Natur</span>
+                        <small>природа</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Hütte</span>
+                        <small>хижина</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Regen</span>
+                        <small>дождь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Donner</span>
+                        <small>гром</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Sturm</span>
+                        <small>буря</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Elend</span>
+                        <small>нищета, бедствие</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Blitz</span>
+                        <small>молния</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>zerbrechen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>разбиваться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>мёрзнуть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>голый, нагой</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>кричать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>die Hütte</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>хижина</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>кричать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>природа</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>безумный</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>wahnsinnig</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>кричать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>природа</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>безумный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>разбиваться</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>der Blitz</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>природа</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>молния</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>разбиваться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>голый, нагой</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>nackt</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>голый, нагой</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>дождь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>разбиваться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>безумный</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Blast, _____! Zerbrich die Welt!</p>
+                    <p class="context-hint">Подсказка: Дуй, буря! Разрушь мир!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Sturm">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ ist meine Stimme!</p>
+                    <p class="context-hint">Подсказка: Гром - мой голос!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Donner">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Bin ich _____ geworden?</p>
+                    <p class="context-hint">Подсказка: Стал ли я безумным?</p>
+                    <input type="text" placeholder="Введите слово" data-correct="wahnsinnig">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">БУРЯ, разорви мир</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">zerreiß</span><span class="draggable" draggable="true">Welt</span><span class="draggable" draggable="true">STURM</span><span class="draggable" draggable="true">die</span></div>
+                    <div class="drop-zone" data-correct="STURM zerreiß die Welt">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">ГРОМ, сокруши всё</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">zerschmettere</span><span class="draggable" draggable="true">alles</span><span class="draggable" draggable="true">DONNER</span></div>
+                    <div class="drop-zone" data-correct="DONNER zerschmettere alles">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1135,7 +1601,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_3_wahnsinn/08_Vstrecha_s_Tomom_B1.html
+++ b/output/b1/gruppe_3_wahnsinn/08_Vstrecha_s_Tomom_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Сцена 8: Встреча с Эдгаром-Томом</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -847,7 +848,472 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="безумие">
+                    <span class="word-main">der Wahnsinn</span>
+                    <small class="word-hint">[дер ВАХН-зин]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="дрожать">
+                    <span class="word-main">zittern</span>
+                    <small class="word-hint">[ЦИТ-терн]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="узнавать">
+                    <span class="word-main">erkennen</span>
+                    <small class="word-hint">[ер-КЕН-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="философ">
+                    <span class="word-main">der Philosoph</span>
+                    <small class="word-hint">[дер фи-ло-ЗОФ]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="разум">
+                    <span class="word-main">der Verstand</span>
+                    <small class="word-hint">[дер фер-ШТАНД]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="тьма, мрак">
+                    <span class="word-main">die Finsternis</span>
+                    <small class="word-hint">[ди ФИН-стер-нис]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="притворяться">
+                    <span class="word-main">verstellen</span>
+                    <small class="word-hint">[фер-ШТЕ-лен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="нищий">
+                    <span class="word-main">der Bettler</span>
+                    <small class="word-hint">[дер БЕТТ-лер]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="тьма, мрак">
+                    тьма, мрак
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="философ">
+                    философ
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="узнавать">
+                    узнавать
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="безумие">
+                    безумие
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="нищий">
+                    нищий
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="притворяться">
+                    притворяться
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="разум">
+                    разум
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="дрожать">
+                    дрожать
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Bettler</span>
+                        <small>нищий</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Dämonen</span>
+                        <small>демоны</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Lumpen</span>
+                        <small>лохмотья</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Philosoph</span>
+                        <small>философ</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Verstand</span>
+                        <small>разум</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Finsternis</span>
+                        <small>тьма, мрак</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Wahnsinn</span>
+                        <small>безумие</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>der Bettler</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>узнавать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>лохмотья</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>нищий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>демоны</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>der Philosoph</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>лохмотья</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>философ</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>узнавать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>демоны</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>erkennen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>тьма, мрак</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>дрожать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>притворяться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>узнавать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>zittern</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>узнавать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>демоны</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>дрожать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>притворяться</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>flüstern</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>лохмотья</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>шептать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>дрожать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>нищий</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Tom ist ein armer _____!</p>
+                    <p class="context-hint">Подсказка: Том - бедный нищий!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Bettler">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ist das der _____?</p>
+                    <p class="context-hint">Подсказка: Это ли безумие?</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Wahnsinn">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Die _____ verfolgen mich!</p>
+                    <p class="context-hint">Подсказка: Демоны преследуют меня!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Dämonen">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Том - НИЩИЙ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">BETTLER</span><span class="draggable" draggable="true">ein</span><span class="draggable" draggable="true">Tom</span><span class="draggable" draggable="true">ist</span></div>
+                    <div class="drop-zone" data-correct="Tom ist ein BETTLER">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">ДЕМОНЫ гонятся за мной</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Die</span><span class="draggable" draggable="true">DÄMONEN</span><span class="draggable" draggable="true">jagen</span><span class="draggable" draggable="true">mich</span></div>
+                    <div class="drop-zone" data-correct="Die DÄMONEN jagen mich">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1135,7 +1601,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_3_wahnsinn/09_Osleplenie_Glostera_B1.html
+++ b/output/b1/gruppe_3_wahnsinn/09_Osleplenie_Glostera_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Сцена 9: Ослепление Глостера</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -847,7 +848,472 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="кричать">
+                    <span class="word-main">schreien</span>
+                    <small class="word-hint">[ШРАЙ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="вырывать">
+                    <span class="word-main">ausreißen</span>
+                    <small class="word-hint">[АУС-райсен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="милость">
+                    <span class="word-main">die Gnade</span>
+                    <small class="word-hint">[ди ГНА-де]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="темнота">
+                    <span class="word-main">die Dunkelheit</span>
+                    <small class="word-hint">[ди ДУН-кель-хайт]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="связывать">
+                    <span class="word-main">binden</span>
+                    <small class="word-hint">[БИН-ден]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="глаза">
+                    <span class="word-main">die Augen</span>
+                    <small class="word-hint">[ди АУ-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="месть">
+                    <span class="word-main">die Rache</span>
+                    <small class="word-hint">[ди РА-хе]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="предатель">
+                    <span class="word-main">der Verräter</span>
+                    <small class="word-hint">[дер фер-РЕ-тер]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="темнота">
+                    темнота
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="предатель">
+                    предатель
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="милость">
+                    милость
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="кричать">
+                    кричать
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="глаза">
+                    глаза
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="месть">
+                    месть
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="связывать">
+                    связывать
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="вырывать">
+                    вырывать
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Rache</span>
+                        <small>месть</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Blut</span>
+                        <small>кровь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Verräter</span>
+                        <small>предатель</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Dunkelheit</span>
+                        <small>темнота</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Augen</span>
+                        <small>глаза</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Gnade</span>
+                        <small>милость</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Folter</span>
+                        <small>пытка</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>der Verräter</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>кричать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>предатель</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>жестокий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>связывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>die Gnade</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>месть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>связывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>предатель</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>милость</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>blind</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>пытка</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>связывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>слепой</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>кричать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Augen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>милость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>глаза</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>месть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>связывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Rache</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>глаза</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>темнота</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>кричать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>месть</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Aus mit seinen _____!</p>
+                    <p class="context-hint">Подсказка: Вырвать его глаза!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Augen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich bin _____! Völlig blind!</p>
+                    <p class="context-hint">Подсказка: Я слеп! Совершенно слеп!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="blind">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Die _____ für Verräter!</p>
+                    <p class="context-hint">Подсказка: Пытка для предателей!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Folter">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">СВЯЖИТЕ ПРЕДАТЕЛЯ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">VERRÄTER</span><span class="draggable" draggable="true">BINDET</span><span class="draggable" draggable="true">den</span></div>
+                    <div class="drop-zone" data-correct="BINDET den VERRÄTER">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Его ГЛАЗА увидят МЕСТЬ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">die</span><span class="draggable" draggable="true">werden</span><span class="draggable" draggable="true">sehen</span><span class="draggable" draggable="true">AUGEN</span><span class="draggable" draggable="true">Seine</span><span class="draggable" draggable="true">RACHE</span></div>
+                    <div class="drop-zone" data-correct="Seine AUGEN werden die RACHE sehen">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1135,7 +1601,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_4_erkenntnis/10_Duvrskie_skaly_B1.html
+++ b/output/b1/gruppe_4_erkenntnis/10_Duvrskie_skaly_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 🏔 Сцена 10: Дуврские скалы</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -847,7 +848,448 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="обманывать">
+                    <span class="word-main">täuschen</span>
+                    <small class="word-hint">[ТОЙ-шен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="падать">
+                    <span class="word-main">fallen</span>
+                    <small class="word-hint">[ФА-лен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="чудо">
+                    <span class="word-main">das Wunder</span>
+                    <small class="word-hint">[дас ВУНД-ер]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="самоубийство">
+                    <span class="word-main">der Selbstmord</span>
+                    <small class="word-hint">[дер ЗЕЛЬБСТ-морд]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="спасать">
+                    <span class="word-main">retten</span>
+                    <small class="word-hint">[РЕ-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="вести">
+                    <span class="word-main">führen</span>
+                    <small class="word-hint">[ФЮ-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="высота">
+                    <span class="word-main">die Höhe</span>
+                    <small class="word-hint">[ди ХЁ-хе]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="отчаиваться">
+                    <span class="word-main">verzweifeln</span>
+                    <small class="word-hint">[фер-ЦВАЙ-фельн]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="самоубийство">
+                    самоубийство
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="чудо">
+                    чудо
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="обманывать">
+                    обманывать
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="вести">
+                    вести
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="падать">
+                    падать
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="отчаиваться">
+                    отчаиваться
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="спасать">
+                    спасать
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="высота">
+                    высота
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Wunder</span>
+                        <small>чудо</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Klippe</span>
+                        <small>утёс</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Selbstmord</span>
+                        <small>самоубийство</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Höhe</span>
+                        <small>высота</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Abgrund</span>
+                        <small>пропасть</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>das Wunder</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>обманывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>чудо</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>пропасть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>падать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>retten</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>жить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>чудо</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>спасать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>самоубийство</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>die Höhe</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>прыгать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>чудо</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>высота</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>обманывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>fallen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>отчаиваться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>жить</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>утёс</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>падать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Klippe</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>утёс</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>чудо</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>самоубийство</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>вести</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Hier ist die höchste _____</p>
+                    <p class="context-hint">Подсказка: Вот самый высокий утёс</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Klippe">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich werde _____</p>
+                    <p class="context-hint">Подсказка: Я прыгну</p>
+                    <input type="text" placeholder="Введите слово" data-correct="springen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ ist mein Ausweg</p>
+                    <p class="context-hint">Подсказка: Самоубийство - мой выход</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Selbstmord">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Вот УТЁС</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">die</span><span class="draggable" draggable="true">Hier</span><span class="draggable" draggable="true">KLIPPE</span><span class="draggable" draggable="true">ist</span></div>
+                    <div class="drop-zone" data-correct="Hier ist die KLIPPE">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">САМОУБИЙСТВО - моё избавление</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">SELBSTMORD</span><span class="draggable" draggable="true">meine</span><span class="draggable" draggable="true">Der</span><span class="draggable" draggable="true">Erlösung</span><span class="draggable" draggable="true">ist</span></div>
+                    <div class="drop-zone" data-correct="Der SELBSTMORD ist meine Erlösung">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1135,7 +1577,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_4_erkenntnis/11_Primirenie_s_Kordeliey_B1.html
+++ b/output/b1/gruppe_4_erkenntnis/11_Primirenie_s_Kordeliey_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 →❤ Сцена 11: Примирение с Корделией</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -859,7 +860,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="слёзы">
+                    <span class="word-main">die Tränen</span>
+                    <small class="word-hint">[ди ТРЕ-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="узнавать">
+                    <span class="word-main">erkennen</span>
+                    <small class="word-hint">[ер-КЕН-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="обнимать">
+                    <span class="word-main">umarmen</span>
+                    <small class="word-hint">[ум-АР-мен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="дочь">
+                    <span class="word-main">die Tochter</span>
+                    <small class="word-hint">[ди ТОХ-тер]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="нежный">
+                    <span class="word-main">sanft</span>
+                    <small class="word-hint">[ЗАНФТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="плакать">
+                    <span class="word-main">weinen</span>
+                    <small class="word-hint">[ВАЙ-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="пробуждение">
+                    <span class="word-main">das Erwachen</span>
+                    <small class="word-hint">[дас ер-ВА-хен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="прощение">
+                    <span class="word-main">die Vergebung</span>
+                    <small class="word-hint">[ди фер-ГЕ-бунг]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="нежный">
+                    нежный
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="плакать">
+                    плакать
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="пробуждение">
+                    пробуждение
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="слёзы">
+                    слёзы
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="обнимать">
+                    обнимать
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="прощение">
+                    прощение
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="узнавать">
+                    узнавать
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="дочь">
+                    дочь
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Reue</span>
+                        <small>раскаяние</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Liebe</span>
+                        <small>любовь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Erwachen</span>
+                        <small>пробуждение</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Tränen</span>
+                        <small>слёзы</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Vergebung</span>
+                        <small>прощение</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Tochter</span>
+                        <small>дочь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>sanft</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>плакать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>нежный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>исцелять</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>узнавать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>die Liebe</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>нежный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>плакать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>любовь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>пробуждение</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>die Reue</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>раскаяние</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>дочь</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>прощать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>плакать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Tränen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>узнавать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>слёзы</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>обнимать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>пробуждение</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>erkennen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>прощать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>обнимать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>узнавать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>любовь</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Sind das deine _____?</p>
+                    <p class="context-hint">Подсказка: Это твои слёзы?</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Tränen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Lass mich dich _____</p>
+                    <p class="context-hint">Подсказка: Позволь мне обнять тебя</p>
+                    <input type="text" placeholder="Введите слово" data-correct="umarmen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Bist du meine _____?</p>
+                    <p class="context-hint">Подсказка: Ты моя дочь?</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Tochter">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Знаешь ли ты меня, милорд</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">mich</span><span class="draggable" draggable="true">mein</span><span class="draggable" draggable="true">du</span><span class="draggable" draggable="true">Herr</span><span class="draggable" draggable="true">Kennst</span></div>
+                    <div class="drop-zone" data-correct="Kennst du mich mein Herr">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Ты дух, я знаю это</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">es</span><span class="draggable" draggable="true">ein</span><span class="draggable" draggable="true">Geist</span><span class="draggable" draggable="true">weiß</span><span class="draggable" draggable="true">Du</span><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">bist</span></div>
+                    <div class="drop-zone" data-correct="Du bist ein Geist ich weiß es">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1147,7 +1601,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_4_erkenntnis/12_Prozrenie_Lira_B1.html
+++ b/output/b1/gruppe_4_erkenntnis/12_Prozrenie_Lira_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Сцена 12: Прозрение Лира</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -858,7 +859,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="смирение">
+                    <span class="word-main">die Demut</span>
+                    <small class="word-hint">[ди ДЕ-мут]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="ясный">
+                    <span class="word-main">klar</span>
+                    <small class="word-hint">[КЛАР]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="сожалеть">
+                    <span class="word-main">bereuen</span>
+                    <small class="word-hint">[бе-РОЙ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="виновный">
+                    <span class="word-main">schuldig</span>
+                    <small class="word-hint">[ШУЛЬ-диг]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="прозрение">
+                    <span class="word-main">die Einsicht</span>
+                    <small class="word-hint">[ди АЙН-зихт]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="познание">
+                    <span class="word-main">die Erkenntnis</span>
+                    <small class="word-hint">[ди ер-КЕНТ-нис]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="мудрость">
+                    <span class="word-main">die Weisheit</span>
+                    <small class="word-hint">[ди ВАЙС-хайт]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="заблуждение">
+                    <span class="word-main">der Irrtum</span>
+                    <small class="word-hint">[дер ИР-тум]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="прозрение">
+                    прозрение
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="смирение">
+                    смирение
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="виновный">
+                    виновный
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="заблуждение">
+                    заблуждение
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="сожалеть">
+                    сожалеть
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="ясный">
+                    ясный
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="познание">
+                    познание
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="мудрость">
+                    мудрость
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Erkenntnis</span>
+                        <small>познание</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Wahrheit</span>
+                        <small>правда</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Einsicht</span>
+                        <small>прозрение</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Demut</span>
+                        <small>смирение</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Irrtum</span>
+                        <small>заблуждение</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Weisheit</span>
+                        <small>мудрость</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>bereuen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>сожалеть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>прозрение</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>пробуждаться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>правда</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>erwachen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>видеть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>сожалеть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>пробуждаться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>виновный</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>die Wahrheit</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>мудрость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>виновный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>смирение</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>правда</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>verstehen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>смирение</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>заблуждение</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>сожалеть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>понимать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>klar</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>прозрение</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>ясный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>познание</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>виновный</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Die _____ war vor meinen Augen verborgen</p>
+                    <p class="context-hint">Подсказка: Правда была скрыта от моих глаз</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Wahrheit">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Diese _____ kam zu spät</p>
+                    <p class="context-hint">Подсказка: Это познание пришло слишком поздно</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Erkenntnis">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Die _____ kommt durch Leiden</p>
+                    <p class="context-hint">Подсказка: Мудрость приходит через страдание</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Weisheit">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Что я без моей короны</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Krone</span><span class="draggable" draggable="true">ohne</span><span class="draggable" draggable="true">meine</span><span class="draggable" draggable="true">bin</span><span class="draggable" draggable="true">Was</span><span class="draggable" draggable="true">ich</span></div>
+                    <div class="drop-zone" data-correct="Was bin ich ohne meine Krone">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Человек, не больше и не меньше</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">nicht</span><span class="draggable" draggable="true">mehr</span><span class="draggable" draggable="true">Mensch</span><span class="draggable" draggable="true">Ein</span><span class="draggable" draggable="true">und</span><span class="draggable" draggable="true">weniger</span><span class="draggable" draggable="true">nicht</span></div>
+                    <div class="drop-zone" data-correct="Ein Mensch nicht mehr und nicht weniger">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1146,7 +1600,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_5_finale/13_Bitva_B1.html
+++ b/output/b1/gruppe_5_finale/13_Bitva_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Битва</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -858,7 +859,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="сражаться">
+                    <span class="word-main">kämpfen</span>
+                    <small class="word-hint">[КЕМП-фен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="атаковать">
+                    <span class="word-main">angreifen</span>
+                    <small class="word-hint">[АН-грай-фен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="победа">
+                    <span class="word-main">der Sieg</span>
+                    <small class="word-hint">[дер ЗИГ]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="побеждать">
+                    <span class="word-main">siegen</span>
+                    <small class="word-hint">[ЗИ-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="защищать">
+                    <span class="word-main">verteidigen</span>
+                    <small class="word-hint">[фер-ТАЙ-ди-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="битва">
+                    <span class="word-main">die Schlacht</span>
+                    <small class="word-hint">[ди ШЛАХТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="пасть">
+                    <span class="word-main">fallen</span>
+                    <small class="word-hint">[ФА-лен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="война">
+                    <span class="word-main">der Krieg</span>
+                    <small class="word-hint">[дер КРИГ]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="защищать">
+                    защищать
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="сражаться">
+                    сражаться
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="пасть">
+                    пасть
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="побеждать">
+                    побеждать
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="война">
+                    война
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="битва">
+                    битва
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="победа">
+                    победа
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="атаковать">
+                    атаковать
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Schlacht</span>
+                        <small>битва</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Sieg</span>
+                        <small>победа</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Schwert</span>
+                        <small>меч</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Armee</span>
+                        <small>армия</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Krieg</span>
+                        <small>война</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Niederlage</span>
+                        <small>поражение</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>die Schlacht</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>битва</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>меч</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>защищать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>побеждать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>die Niederlage</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>атаковать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>проигрывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>поражение</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>пасть</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>siegen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>сражаться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>атаковать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>побеждать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>победа</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>verlieren</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>проигрывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>победа</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>поражение</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>меч</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>der Sieg</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>пасть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>защищать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>победа</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>битва</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Wir müssen _____ für Gerechtigkeit!</p>
+                    <p class="context-hint">Подсказка: Мы должны сражаться за справедливость!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="kämpfen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Mein _____ für den König!</p>
+                    <p class="context-hint">Подсказка: Мой меч за короля!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Schwert">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ entscheidet alles</p>
+                    <p class="context-hint">Подсказка: Война решает всё</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Krieg">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Победа будет нашей</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">unser</span><span class="draggable" draggable="true">sein</span><span class="draggable" draggable="true">Sieg</span><span class="draggable" draggable="true">wird</span><span class="draggable" draggable="true">Der</span></div>
+                    <div class="drop-zone" data-correct="Der Sieg wird unser sein">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Справедливость восторжествует</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">wird</span><span class="draggable" draggable="true">siegen</span><span class="draggable" draggable="true">Gerechtigkeit</span></div>
+                    <div class="drop-zone" data-correct="Gerechtigkeit wird siegen">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1146,7 +1600,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_5_finale/14_Duel_bratev_B1.html
+++ b/output/b1/gruppe_5_finale/14_Duel_bratev_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Дуэль братьев</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -858,7 +859,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="разоблачать">
+                    <span class="word-main">enthüllen</span>
+                    <small class="word-hint">[ент-ХЮЛ-лен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="мстить">
+                    <span class="word-main">rächen</span>
+                    <small class="word-hint">[РЕ-хен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="вызывать">
+                    <span class="word-main">herausfordern</span>
+                    <small class="word-hint">[хер-АУС-фор-дерн]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="дуэль">
+                    <span class="word-main">das Duell</span>
+                    <small class="word-hint">[дас ду-ЕЛЬ]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="умирать">
+                    <span class="word-main">sterben</span>
+                    <small class="word-hint">[ШТЕР-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="брат">
+                    <span class="word-main">der Bruder</span>
+                    <small class="word-hint">[дер БРУ-дер]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="убивать">
+                    <span class="word-main">töten</span>
+                    <small class="word-hint">[ТЁ-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="признаваться">
+                    <span class="word-main">gestehen</span>
+                    <small class="word-hint">[ге-ШТЕ-ен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="брат">
+                    брат
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="умирать">
+                    умирать
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="разоблачать">
+                    разоблачать
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="вызывать">
+                    вызывать
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="убивать">
+                    убивать
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="признаваться">
+                    признаваться
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="дуэль">
+                    дуэль
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="мстить">
+                    мстить
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Klinge</span>
+                        <small>клинок</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Ehre</span>
+                        <small>честь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Duell</span>
+                        <small>дуэль</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Bruder</span>
+                        <small>брат</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Zweikampf</span>
+                        <small>поединок</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Gerechtigkeit</span>
+                        <small>справедливость</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>der Zweikampf</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>клинок</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>поединок</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>признаваться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>дуэль</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>die Gerechtigkeit</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>поединок</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>убивать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>справедливость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>вызывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>töten</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>вызывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>убивать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>клинок</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>признаваться</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>sterben</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>признаваться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>умирать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>справедливость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>честь</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>der Bruder</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>поединок</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>разоблачать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>брат</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>вызывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Meine _____ fordert Genugtuung!</p>
+                    <p class="context-hint">Подсказка: Моя честь требует удовлетворения!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Ehre">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich nehme dein _____ an</p>
+                    <p class="context-hint">Подсказка: Я принимаю твою дуэль</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Duell">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ beginnt!</p>
+                    <p class="context-hint">Подсказка: Поединок начинается!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Zweikampf">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Твоя кровь — яд, предатель</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Dein</span><span class="draggable" draggable="true">Verräter</span><span class="draggable" draggable="true">Gift</span><span class="draggable" draggable="true">ist</span><span class="draggable" draggable="true">Blut</span></div>
+                    <div class="drop-zone" data-correct="Dein Blut ist Gift Verräter">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Ты говоришь правду</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">die</span><span class="draggable" draggable="true">Du</span><span class="draggable" draggable="true">sprichst</span><span class="draggable" draggable="true">Wahrheit</span></div>
+                    <div class="drop-zone" data-correct="Du sprichst die Wahrheit">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1146,7 +1600,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/b1/gruppe_5_finale/15_Smert_Kordelii_i_Lira_B1.html
+++ b/output/b1/gruppe_5_finale/15_Smert_Kordelii_i_Lira_B1.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Смерть Корделии и Лира</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -853,7 +854,472 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="вешать">
+                    <span class="word-main">erhängen</span>
+                    <small class="word-hint">[ер-ХЕН-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="дышать">
+                    <span class="word-main">hauchen</span>
+                    <small class="word-hint">[ХАУ-хен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="слишком поздно">
+                    <span class="word-main">zu spät</span>
+                    <small class="word-hint">[цу-ШПЕТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="труп">
+                    <span class="word-main">die Leiche</span>
+                    <small class="word-hint">[ди ЛАЙ-хе]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="конец">
+                    <span class="word-main">das Ende</span>
+                    <small class="word-hint">[дас ЕН-де]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="смерть">
+                    <span class="word-main">der Tod</span>
+                    <small class="word-hint">[дер ТОД]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="боль">
+                    <span class="word-main">der Schmerz</span>
+                    <small class="word-hint">[дер ШМЕРЦ]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="разбиваться">
+                    <span class="word-main">brechen</span>
+                    <small class="word-hint">[БРЕ-хен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="конец">
+                    конец
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="боль">
+                    боль
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="дышать">
+                    дышать
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="смерть">
+                    смерть
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="слишком поздно">
+                    слишком поздно
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="вешать">
+                    вешать
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="труп">
+                    труп
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="разбиваться">
+                    разбиваться
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Ende</span>
+                        <small>конец</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Tod</span>
+                        <small>смерть</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Herz</span>
+                        <small>сердце</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Schmerz</span>
+                        <small>боль</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Trauer</span>
+                        <small>скорбь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Abschied</span>
+                        <small>прощание</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Leiche</span>
+                        <small>труп</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>brechen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>разбиваться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>смерть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>конец</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>вешать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>das Herz</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>разбиваться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>конец</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>сердце</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>скорбь</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>erhängen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>труп</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>вешать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>сердце</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>дышать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Leiche</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>сердце</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>боль</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>слишком поздно</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>труп</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Trauer</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>конец</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>сердце</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>слишком поздно</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>скорбь</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Der _____ nimmt alles</p>
+                    <p class="context-hint">Подсказка: Смерть забирает всё</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Tod">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Er trägt ihre _____</p>
+                    <p class="context-hint">Подсказка: Он несёт её тело</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Leiche">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Mein Befehl kam _____</p>
+                    <p class="context-hint">Подсказка: Мой приказ пришёл слишком поздно</p>
+                    <input type="text" placeholder="Введите слово" data-correct="zu spät">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Почему собака, лошадь, крыса имеют жизнь, а ты — нет</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">haben</span><span class="draggable" draggable="true">Leben</span><span class="draggable" draggable="true">ein</span><span class="draggable" draggable="true">du</span><span class="draggable" draggable="true">eine</span><span class="draggable" draggable="true">sollte</span><span class="draggable" draggable="true">Hund</span><span class="draggable" draggable="true">Ratte</span><span class="draggable" draggable="true">Pferd</span><span class="draggable" draggable="true">Warum</span><span class="draggable" draggable="true">nicht</span><span class="draggable" draggable="true">ein</span><span class="draggable" draggable="true">und</span></div>
+                    <div class="drop-zone" data-correct="Warum sollte ein Hund ein Pferd eine Ratte Leben haben und du nicht">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Это ли обещанный конец</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Ist</span><span class="draggable" draggable="true">das</span><span class="draggable" draggable="true">Ende</span><span class="draggable" draggable="true">versprochene</span><span class="draggable" draggable="true">das</span></div>
+                    <div class="drop-zone" data-correct="Ist das das versprochene Ende">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1141,7 +1607,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/book/index.html
+++ b/output/book/index.html
@@ -289,7 +289,7 @@
     </main>
     
     <footer class="book-footer">
-        <p>Generiert am 2025-09-14</p>
+        <p>Generiert am 2025-09-24</p>
         <p>Lir Website Generator - Deutsch durch König Lear</p>
     </footer>
     

--- a/output/book/metadata/search-index.json
+++ b/output/book/metadata/search-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated": "2025-09-14T17:10:05.304194",
+  "generated": "2025-09-24T11:04:58.664341",
   "documents": [
     {
       "id": "chapter-1-chunk-1",

--- a/output/css/exercises.css
+++ b/output/css/exercises.css
@@ -1,0 +1,454 @@
+
+/* ===== СТИЛИ ДЛЯ ИНТЕРАКТИВНЫХ УПРАЖНЕНИЙ ===== */
+
+.exercises-section {
+    margin: 40px 0;
+    padding: 30px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border-radius: 20px;
+    color: #1f2937;
+}
+
+.exercises-section .section-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 24px;
+    color: #ffffff;
+    margin-bottom: 20px;
+}
+
+.exercises-section .section-title .icon {
+    font-size: 30px;
+}
+
+.exercises-accordion {
+    margin-top: 15px;
+}
+
+.exercise-accordion-item {
+    background: #ffffff;
+    border-radius: 12px;
+    margin-bottom: 15px;
+    box-shadow: 0 12px 32px rgba(76, 29, 149, 0.18);
+    overflow: hidden;
+}
+
+.exercise-accordion-item summary {
+    cursor: pointer;
+    padding: 18px 22px;
+    font-size: 18px;
+    font-weight: 600;
+    color: #4338ca;
+    background: rgba(99, 102, 241, 0.08);
+    transition: all 0.3s ease;
+    list-style: none;
+}
+
+.exercise-accordion-item[open] summary {
+    background: rgba(99, 102, 241, 0.16);
+}
+
+.exercise-accordion-item summary::-webkit-details-marker {
+    display: none;
+}
+
+.exercise-accordion-item summary::after {
+    content: '▾';
+    float: right;
+    transition: transform 0.3s ease;
+}
+
+.exercise-accordion-item[open] summary::after {
+    transform: rotate(180deg);
+}
+
+.exercise-content {
+    padding: 20px 24px 30px 24px;
+}
+
+.exercise-block {
+    background: #f9fafb;
+    border-radius: 14px;
+    padding: 20px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.exercise-title {
+    font-size: 20px;
+    margin-bottom: 10px;
+    color: #1f2937;
+}
+
+.exercise-intro {
+    margin: 0 0 15px 0;
+    color: #4b5563;
+}
+
+.check-btn {
+    margin-top: 20px;
+    padding: 12px 28px;
+    background: linear-gradient(135deg, #6366f1 0%, #7c3aed 100%);
+    border: none;
+    color: white;
+    font-weight: 600;
+    border-radius: 10px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 8px 20px rgba(79, 70, 229, 0.35);
+}
+
+.check-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 28px rgba(79, 70, 229, 0.4);
+}
+
+.check-btn:active {
+    transform: translateY(0);
+}
+
+/* Word Matching */
+.matching-container {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.words-column,
+.translations-column {
+    flex: 1;
+    min-width: 260px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.word-item,
+.translation-item {
+    background: white;
+    border-radius: 10px;
+    padding: 14px 16px;
+    border: 2px solid transparent;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 8px 20px rgba(148, 163, 184, 0.25);
+}
+
+.word-item:hover,
+.translation-item:hover {
+    border-color: #c7d2fe;
+}
+
+.word-item.selected,
+.word-item.paired,
+.translation-item.selected {
+    border-color: #6366f1;
+    background: #eef2ff;
+}
+
+.word-item.correct,
+.translation-item.correct {
+    border-color: #10b981;
+    background: #d1fae5;
+}
+
+.word-item.incorrect,
+.translation-item.incorrect {
+    border-color: #ef4444;
+    background: #fee2e2;
+}
+
+/* Articles */
+.articles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+}
+
+.article-item {
+    background: white;
+    border-radius: 12px;
+    padding: 16px;
+    text-align: center;
+    border: 2px solid transparent;
+    transition: border-color 0.2s ease;
+}
+
+.article-word .noun {
+    display: block;
+    font-size: 20px;
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+.article-word small {
+    color: #6b7280;
+}
+
+.article-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.article-buttons button {
+    padding: 8px 16px;
+    border-radius: 8px;
+    background: #f3f4f6;
+    border: 1px solid #d1d5db;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.article-buttons button.selected {
+    background: #6366f1;
+    color: white;
+    border-color: #4f46e5;
+}
+
+.article-buttons button.correct {
+    background: #10b981;
+    border-color: #059669;
+}
+
+.article-buttons button.incorrect {
+    background: #ef4444;
+    border-color: #dc2626;
+    color: white;
+}
+
+/* Synonyms */
+.synonym-item {
+    background: white;
+    border-radius: 12px;
+    padding: 16px;
+    margin-bottom: 14px;
+    display: flex;
+    gap: 18px;
+    align-items: center;
+    box-shadow: 0 6px 14px rgba(79, 70, 229, 0.12);
+}
+
+.word-center {
+    min-width: 160px;
+    text-align: center;
+}
+
+.word-center .word-main {
+    display: block;
+    font-weight: 600;
+    font-size: 20px;
+    color: #4338ca;
+}
+
+.word-center small {
+    color: #6b7280;
+}
+
+.synonym-item input {
+    padding: 10px 14px;
+    border-radius: 8px;
+    border: 2px solid #d1d5db;
+    font-size: 16px;
+    width: 220px;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.synonym-item input:focus {
+    outline: none;
+    border-color: #6366f1;
+    background: #eef2ff;
+}
+
+.synonym-item input.correct {
+    border-color: #10b981;
+    background: #ecfdf5;
+}
+
+.synonym-item input.incorrect {
+    border-color: #ef4444;
+    background: #fef2f2;
+}
+
+/* Quiz */
+.quiz-question {
+    background: white;
+    border-radius: 12px;
+    padding: 18px;
+    margin-bottom: 16px;
+    box-shadow: 0 8px 18px rgba(148, 163, 184, 0.18);
+}
+
+.quiz-question .question {
+    margin-bottom: 14px;
+    font-size: 18px;
+    color: #1f2937;
+}
+
+.quiz-options {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.quiz-options label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: #f9fafb;
+    border-radius: 8px;
+    padding: 10px 12px;
+    border: 2px solid transparent;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.quiz-options label.correct {
+    border-color: #10b981;
+    background: #ecfdf5;
+}
+
+.quiz-options label.incorrect {
+    border-color: #ef4444;
+    background: #fee2e2;
+}
+
+.quiz-options input[type="radio"] {
+    accent-color: #6366f1;
+}
+
+/* Context */
+.context-item {
+    background: white;
+    border-radius: 12px;
+    padding: 18px;
+    margin-bottom: 14px;
+    box-shadow: 0 6px 16px rgba(79, 70, 229, 0.12);
+}
+
+.context-german {
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 8px;
+}
+
+.context-hint {
+    color: #6b7280;
+    margin-bottom: 12px;
+}
+
+.context-item input {
+    width: 100%;
+    padding: 10px 14px;
+    border-radius: 8px;
+    border: 2px solid #d1d5db;
+    font-size: 16px;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.context-item input.correct {
+    border-color: #10b981;
+    background: #ecfdf5;
+}
+
+.context-item input.incorrect {
+    border-color: #ef4444;
+    background: #fef2f2;
+}
+
+/* Sentence builder */
+.sentence-builder {
+    background: white;
+    border-radius: 12px;
+    padding: 20px;
+    margin-bottom: 18px;
+    box-shadow: 0 8px 18px rgba(148, 163, 184, 0.18);
+}
+
+.sentence-builder .translation {
+    margin-bottom: 12px;
+    color: #374151;
+}
+
+.word-pool {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.draggable {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 14px;
+    background: #6366f1;
+    color: white;
+    border-radius: 8px;
+    cursor: grab;
+    user-select: none;
+    transition: transform 0.2s ease;
+}
+
+.draggable:active {
+    cursor: grabbing;
+    transform: scale(0.96);
+}
+
+.drop-zone {
+    min-height: 56px;
+    border: 2px dashed #c7d2fe;
+    border-radius: 10px;
+    padding: 12px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    background: #f5f3ff;
+}
+
+.drop-zone.drag-over {
+    border-color: #4338ca;
+    background: #ede9fe;
+}
+
+.drop-zone.correct {
+    border-color: #10b981;
+}
+
+.drop-zone.incorrect {
+    border-color: #ef4444;
+}
+
+.drop-zone .placeholder {
+    color: #9ca3af;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .exercises-section {
+        padding: 22px;
+    }
+
+    .exercise-content {
+        padding: 16px 18px 24px 18px;
+    }
+
+    .synonym-item {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .synonym-item input {
+        width: 100%;
+    }
+
+    .matching-container {
+        flex-direction: column;
+    }
+
+    .word-pool {
+        justify-content: center;
+    }
+}

--- a/output/js/exercises.js
+++ b/output/js/exercises.js
@@ -1,0 +1,312 @@
+
+/* ===== JAVASCRIPT ДЛЯ ИНТЕРАКТИВНЫХ УПРАЖНЕНИЙ ===== */
+
+(function() {
+    'use strict';
+
+    function showResult(message) {
+        if (typeof window !== 'undefined') {
+            window.alert(message);
+        }
+    }
+
+    // 1. Word matching
+    document.addEventListener('click', function(event) {
+        const wordItem = event.target.closest('.word-item');
+        const translationItem = event.target.closest('.translation-item');
+
+        if (wordItem) {
+            document.querySelectorAll('.word-item').forEach(item => {
+                item.classList.remove('selected');
+            });
+            wordItem.classList.add('selected');
+            document.body.dataset.selectedWordId = wordItem.dataset.id;
+        }
+
+        if (translationItem) {
+            const selectedId = document.body.dataset.selectedWordId;
+            if (!selectedId) {
+                return;
+            }
+            const word = document.querySelector(`.word-item[data-id="${selectedId}"]`);
+            if (!word) {
+                return;
+            }
+
+            // Remove previous binding for this word
+            if (word.dataset.selectedId) {
+                const previousTranslation = document.querySelector(`.translation-item[data-id="${word.dataset.selectedId}"]`);
+                if (previousTranslation) {
+                    previousTranslation.classList.remove('selected');
+                    delete previousTranslation.dataset.selectedBy;
+                }
+            }
+
+            // If translation already linked to another word - unlink it
+            if (translationItem.dataset.selectedBy) {
+                const previousWord = document.querySelector(`.word-item[data-id="${translationItem.dataset.selectedBy}"]`);
+                if (previousWord) {
+                    delete previousWord.dataset.selectedId;
+                    previousWord.classList.remove('paired');
+                }
+            }
+
+            translationItem.classList.add('selected');
+            translationItem.dataset.selectedBy = selectedId;
+            word.dataset.selectedId = translationItem.dataset.id;
+            word.dataset.selected = translationItem.dataset.trans;
+            word.classList.add('paired');
+            document.body.dataset.selectedWordId = '';
+        }
+    });
+
+    document.addEventListener('click', function(event) {
+        const action = event.target.closest('[data-action]');
+        if (!action) {
+            return;
+        }
+
+        switch (action.dataset.action) {
+            case 'check-matching':
+                checkMatching();
+                break;
+            case 'check-articles':
+                checkArticles();
+                break;
+            case 'check-synonyms':
+                checkSynonyms();
+                break;
+            case 'check-quiz':
+                checkQuiz();
+                break;
+            case 'check-context':
+                checkContext();
+                break;
+            case 'check-builder':
+                checkBuilder();
+                break;
+            default:
+                break;
+        }
+    });
+
+    function resetClasses(selector) {
+        document.querySelectorAll(selector).forEach(element => {
+            element.classList.remove('correct', 'incorrect');
+        });
+    }
+
+    function checkMatching() {
+        resetClasses('.word-item');
+        resetClasses('.translation-item');
+        const words = document.querySelectorAll('.word-item');
+        let correct = 0;
+
+        words.forEach(word => {
+            const selected = word.dataset.selected;
+            const answer = word.dataset.answer;
+            const translationId = word.dataset.selectedId;
+            if (!selected || !answer) {
+                return;
+            }
+            const translationItem = translationId ? document.querySelector(`.translation-item[data-id="${translationId}"]`) : null;
+            const isCorrect = selected === answer;
+            if (isCorrect) {
+                word.classList.add('correct');
+                if (translationItem) {
+                    translationItem.classList.add('correct');
+                }
+                correct += 1;
+            } else {
+                word.classList.add('incorrect');
+                if (translationItem) {
+                    translationItem.classList.add('incorrect');
+                }
+            }
+        });
+
+        showResult(`Правильно: ${correct} из ${words.length}`);
+    }
+
+    // 2. Articles
+    document.addEventListener('click', function(event) {
+        if (!event.target.matches('.article-buttons button')) {
+            return;
+        }
+        const button = event.target;
+        const container = button.closest('.article-buttons');
+        container.querySelectorAll('button').forEach(item => item.classList.remove('selected'));
+        button.classList.add('selected');
+    });
+
+    function checkArticles() {
+        resetClasses('.article-buttons button');
+        const items = document.querySelectorAll('.article-item');
+        let correct = 0;
+
+        items.forEach(item => {
+            const selected = item.querySelector('.article-buttons button.selected');
+            if (!selected) {
+                return;
+            }
+            if (selected.dataset.article === item.dataset.correct) {
+                selected.classList.add('correct');
+                item.classList.add('correct');
+                correct += 1;
+            } else {
+                selected.classList.add('incorrect');
+                item.classList.add('incorrect');
+            }
+        });
+
+        showResult(`Правильно: ${correct} из ${items.length}`);
+    }
+
+    // 3. Synonyms & Antonyms
+    function checkSynonyms() {
+        const inputs = document.querySelectorAll('#synonyms input');
+        let correct = 0;
+        inputs.forEach(input => {
+            const expected = (input.dataset.correct || '').trim().toLowerCase();
+            const value = (input.value || '').trim().toLowerCase();
+            if (!expected) {
+                return;
+            }
+            if (value === expected) {
+                input.classList.add('correct');
+                input.classList.remove('incorrect');
+                correct += 1;
+            } else {
+                input.classList.add('incorrect');
+                input.classList.remove('correct');
+            }
+        });
+        showResult(`Правильно: ${correct} из ${inputs.length}`);
+    }
+
+    // 4. Quiz
+    function checkQuiz() {
+        const questions = document.querySelectorAll('.quiz-question');
+        let correct = 0;
+        questions.forEach(question => {
+            const options = question.querySelectorAll('label');
+            options.forEach(option => option.classList.remove('correct', 'incorrect'));
+            const selected = question.querySelector('input[type="radio"]:checked');
+            if (!selected) {
+                return;
+            }
+            if (selected.dataset.correct === 'true') {
+                selected.parentElement.classList.add('correct');
+                correct += 1;
+            } else {
+                selected.parentElement.classList.add('incorrect');
+            }
+        });
+        showResult(`Правильно: ${correct} из ${questions.length}`);
+    }
+
+    // 5. Context
+    function checkContext() {
+        const inputs = document.querySelectorAll('#context input');
+        let correct = 0;
+        inputs.forEach(input => {
+            const expected = (input.dataset.correct || '').trim().toLowerCase();
+            const value = (input.value || '').trim().toLowerCase();
+            if (!expected) {
+                return;
+            }
+            if (value === expected) {
+                input.classList.add('correct');
+                input.classList.remove('incorrect');
+                correct += 1;
+            } else {
+                input.classList.add('incorrect');
+                input.classList.remove('correct');
+            }
+        });
+        showResult(`Правильно: ${correct} из ${inputs.length}`);
+    }
+
+    // 6. Sentence builder
+    document.addEventListener('dragstart', function(event) {
+        const draggable = event.target.closest('.draggable');
+        if (!draggable) {
+            return;
+        }
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData('text/plain', draggable.textContent || '');
+        draggable.classList.add('dragging');
+    });
+
+    document.addEventListener('dragend', function(event) {
+        const draggable = event.target.closest('.draggable');
+        if (!draggable) {
+            return;
+        }
+        draggable.classList.remove('dragging');
+    });
+
+    document.addEventListener('dragover', function(event) {
+        const zone = event.target.closest('.drop-zone');
+        if (!zone) {
+            return;
+        }
+        event.preventDefault();
+        zone.classList.add('drag-over');
+    });
+
+    document.addEventListener('dragleave', function(event) {
+        const zone = event.target.closest('.drop-zone');
+        if (!zone) {
+            return;
+        }
+        zone.classList.remove('drag-over');
+    });
+
+    document.addEventListener('drop', function(event) {
+        const zone = event.target.closest('.drop-zone');
+        if (!zone) {
+            return;
+        }
+        event.preventDefault();
+        zone.classList.remove('drag-over');
+        const dragging = document.querySelector('.draggable.dragging');
+        if (!dragging) {
+            return;
+        }
+        const clone = dragging.cloneNode(true);
+        clone.classList.remove('dragging');
+        dragging.remove();
+        zone.appendChild(clone);
+        const placeholder = zone.querySelector('.placeholder');
+        if (placeholder) {
+            placeholder.remove();
+        }
+    });
+
+    function checkBuilder() {
+        const builders = document.querySelectorAll('.sentence-builder');
+        let correct = 0;
+        builders.forEach(builder => {
+            const zone = builder.querySelector('.drop-zone');
+            if (!zone) {
+                return;
+            }
+            const words = Array.from(zone.querySelectorAll('.draggable')).map(item => item.textContent || '');
+            const assembled = words.join(' ').trim();
+            const answer = (zone.dataset.correct || '').trim();
+            if (!answer) {
+                return;
+            }
+            if (assembled === answer) {
+                zone.classList.remove('incorrect');
+                zone.classList.add('correct');
+                correct += 1;
+            } else {
+                zone.classList.remove('correct');
+                zone.classList.add('incorrect');
+            }
+        });
+        showResult(`Правильно: ${correct} из ${builders.length}`);
+    }
+})();

--- a/output/thematic/lessons/bezumie.html
+++ b/output/thematic/lessons/bezumie.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🌟 Безумие и прозрение через Короля Лира</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -855,7 +856,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="безумие">
+                    <span class="word-main">der Wahnsinn</span>
+                    <small class="word-hint">[дер ВАХН-зин]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="постигать">
+                    <span class="word-main">begreifen</span>
+                    <small class="word-hint">[бе-ГРАЙ-фен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="сбитый с толку">
+                    <span class="word-main">verwirrt</span>
+                    <small class="word-hint">[фер-ВИРТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="сумасшедший">
+                    <span class="word-main">verrückt</span>
+                    <small class="word-hint">[фер-РЮКТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="ясность">
+                    <span class="word-main">die Klarheit</span>
+                    <small class="word-hint">[ди КЛАР-хайт]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="дурак/шут">
+                    <span class="word-main">der Narr</span>
+                    <small class="word-hint">[дер НАР]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="блуждать/заблуждаться">
+                    <span class="word-main">irren</span>
+                    <small class="word-hint">[И-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="спутанный">
+                    <span class="word-main">wirr</span>
+                    <small class="word-hint">[ВИРР]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="ясность">
+                    ясность
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="безумие">
+                    безумие
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="сбитый с толку">
+                    сбитый с толку
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="дурак/шут">
+                    дурак/шут
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="сумасшедший">
+                    сумасшедший
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="спутанный">
+                    спутанный
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="постигать">
+                    постигать
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="блуждать/заблуждаться">
+                    блуждать/заблуждаться
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Narr</span>
+                        <small>дурак/шут</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Verwirrung</span>
+                        <small>смятение</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Klarheit</span>
+                        <small>ясность</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Erleuchtung</span>
+                        <small>озарение</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Wahn</span>
+                        <small>бред</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Wahnsinn</span>
+                        <small>безумие</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>wirr</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>бред</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>блуждать/заблуждаться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>безрассудный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>спутанный</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>die Erleuchtung</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>спутанный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>блуждать/заблуждаться</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>постигать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>озарение</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>die Klarheit</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>спутанный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>ясность</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>смятение</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>сумасшедший</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>verwirrt</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>бред</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>сумасшедший</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>спутанный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>сбитый с толку</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>irren</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>спутанный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>безумие</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>озарение</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>блуждать/заблуждаться</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Ist das _____?</p>
+                    <p class="context-hint">Подсказка: Это БЕЗУМИЕ?</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Wahnsinn">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Bin ich _____?</p>
+                    <p class="context-hint">Подсказка: Я СУМАСШЕДШИЙ?</p>
+                    <input type="text" placeholder="Введите слово" data-correct="verrückt">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ sagt Wahrheit!</p>
+                    <p class="context-hint">Подсказка: ДУРАК говорит правду!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Narr">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Это БЕЗУМИЕ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">das</span><span class="draggable" draggable="true">Ist</span><span class="draggable" draggable="true">WAHNSINN</span></div>
+                    <div class="drop-zone" data-correct="Ist das WAHNSINN">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я СУМАСШЕДШИЙ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">VERRÜCKT</span><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">Bin</span></div>
+                    <div class="drop-zone" data-correct="Bin ich VERRÜCKT">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1143,7 +1597,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/bezumiemudrost.html
+++ b/output/thematic/lessons/bezumiemudrost.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🌟 Безумие и мудрость через Короля Лира</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -840,7 +841,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="загадка">
+                    <span class="word-main">das Rätsel</span>
+                    <small class="word-hint">[дас РЕТ-цель]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="рассудок">
+                    <span class="word-main">der Verstand</span>
+                    <small class="word-hint">[дер фер-ШТАНД]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="безумие">
+                    <span class="word-main">der Wahnsinn</span>
+                    <small class="word-hint">[дер ВАХН-зин]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="постигать">
+                    <span class="word-main">begreifen</span>
+                    <small class="word-hint">[бе-ГРАЙ-фен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="смущённый">
+                    <span class="word-main">verwirrt</span>
+                    <small class="word-hint">[фер-ВИРТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="обманывать">
+                    <span class="word-main">täuschen</span>
+                    <small class="word-hint">[ТОЙ-шен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="умный">
+                    <span class="word-main">klug</span>
+                    <small class="word-hint">[КЛУГ]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="дурак/шут">
+                    <span class="word-main">der Narr</span>
+                    <small class="word-hint">[дер НАР]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="безумие">
+                    безумие
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="обманывать">
+                    обманывать
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="смущённый">
+                    смущённый
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="рассудок">
+                    рассудок
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="умный">
+                    умный
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="постигать">
+                    постигать
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="загадка">
+                    загадка
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="дурак/шут">
+                    дурак/шут
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Rätsel</span>
+                        <small>загадка</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Narr</span>
+                        <small>дурак/шут</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Weisheit</span>
+                        <small>мудрость</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Torheit</span>
+                        <small>глупость</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Verstand</span>
+                        <small>рассудок</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Wahnsinn</span>
+                        <small>безумие</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>klug</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>постигать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>сумасшедший</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>обманывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>умный</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>begreifen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>загадка</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>обманывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>умный</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>постигать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>der Wahnsinn</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>безумие</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>постигать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>загадка</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>обманывать</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Torheit</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>рассудок</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>постигать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>глупость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>дурак/шут</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>das Rätsel</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>постигать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>обманывать</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>мудрость</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>загадка</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Der _____ ist mein Lehrer</p>
+                    <p class="context-hint">Подсказка: Безумие — мой учитель</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Wahnsinn">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Die _____ trägt Narrenkleider</p>
+                    <p class="context-hint">Подсказка: Мудрость носит одежды шута</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Weisheit">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Sei _____, aber ehrlich</p>
+                    <p class="context-hint">Подсказка: Будь умна, но честна</p>
+                    <input type="text" placeholder="Введите слово" data-correct="klug">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">БЕЗУМИЕ - мой учитель</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Der</span><span class="draggable" draggable="true">mein</span><span class="draggable" draggable="true">WAHNSINN</span><span class="draggable" draggable="true">Lehrer</span><span class="draggable" draggable="true">ist</span></div>
+                    <div class="drop-zone" data-correct="Der WAHNSINN ist mein Lehrer">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Мой РАССУДОК покидает меня</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">VERSTAND</span><span class="draggable" draggable="true">Mein</span><span class="draggable" draggable="true">mich</span><span class="draggable" draggable="true">verlässt</span></div>
+                    <div class="drop-zone" data-correct="Mein VERSTAND verlässt mich">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1128,7 +1582,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/bogatstvonishcheta.html
+++ b/output/thematic/lessons/bogatstvonishcheta.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Багатство і злидні через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -832,7 +833,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="власність">
+                    <span class="word-main">das Eigentum</span>
+                    <small class="word-hint">[дас АЙ-ген-тум]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="жебрак">
+                    <span class="word-main">der Bettler</span>
+                    <small class="word-hint">[дер БЕТТ-лер]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="втрачати">
+                    <span class="word-main">verlieren</span>
+                    <small class="word-hint">[фер-ЛИ-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="багатий">
+                    <span class="word-main">reich</span>
+                    <small class="word-hint">[РАЙХ]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="жебракувати">
+                    <span class="word-main">betteln</span>
+                    <small class="word-hint">[БЕТ-тельн]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="скарб">
+                    <span class="word-main">der Schatz</span>
+                    <small class="word-hint">[дер ШАТЦ]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="бідність">
+                    <span class="word-main">die Armut</span>
+                    <small class="word-hint">[ди АР-мут]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="багатство">
+                    <span class="word-main">der Reichtum</span>
+                    <small class="word-hint">[дер РАЙХ-тум]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="жебрак">
+                    жебрак
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="багатство">
+                    багатство
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="багатий">
+                    багатий
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="скарб">
+                    скарб
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="жебракувати">
+                    жебракувати
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="власність">
+                    власність
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="втрачати">
+                    втрачати
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="бідність">
+                    бідність
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Eigentum</span>
+                        <small>власність</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Armut</span>
+                        <small>бідність</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Gold</span>
+                        <small>золото</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Schatz</span>
+                        <small>скарб</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Bettler</span>
+                        <small>жебрак</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Reichtum</span>
+                        <small>багатство</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>der Reichtum</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>жебрак</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>багатство</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>власність</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>бідний</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>betteln</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>ділити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>багатство</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>володіти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>жебракувати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>der Bettler</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>жебрак</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>втрачати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>багатий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>багатство</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>verlieren</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>втрачати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>ділити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>бідність</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>власність</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>das Eigentum</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>багатство</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>скарб</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>жебракувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>власність</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Ich war _____ an Töchtern und Land</p>
+                    <p class="context-hint">Подсказка: Я был богат дочерьми и землями</p>
+                    <input type="text" placeholder="Введите слово" data-correct="reich">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">_____ Tom ist nackt und friert</p>
+                    <p class="context-hint">Подсказка: Бедный Том наг и замерзает</p>
+                    <input type="text" placeholder="Введите слово" data-correct="arm">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">_____ ist mehr wert als Liebe</p>
+                    <p class="context-hint">Подсказка: Золото дороже любви</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Gold">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я был БОГАТ землями и дочерьми</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">an</span><span class="draggable" draggable="true">und</span><span class="draggable" draggable="true">REICH</span><span class="draggable" draggable="true">war</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">Land</span><span class="draggable" draggable="true">Töchtern</span></div>
+                    <div class="drop-zone" data-correct="Ich war REICH an Land und Töchtern">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Где моё ЗОЛОТО</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">mein</span><span class="draggable" draggable="true">geblieben</span><span class="draggable" draggable="true">Wo</span><span class="draggable" draggable="true">ist</span><span class="draggable" draggable="true">GOLD</span></div>
+                    <div class="drop-zone" data-correct="Wo ist mein GOLD geblieben">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1120,7 +1574,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/domizgnanie.html
+++ b/output/thematic/lessons/domizgnanie.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Дім і вигнання через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -844,7 +845,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="притулок">
+                    <span class="word-main">das Asyl</span>
+                    <small class="word-hint">[дас а-ЗИЛ]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="бездомний">
+                    <span class="word-main">obdachlos</span>
+                    <small class="word-hint">[ОБ-дах-лос]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="відкинути">
+                    <span class="word-main">verstoßen</span>
+                    <small class="word-hint">[фер-ШТО-сен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="блукати">
+                    <span class="word-main">wandern</span>
+                    <small class="word-hint">[ВАН-дерн]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="вигнати">
+                    <span class="word-main">verbannen</span>
+                    <small class="word-hint">[фер-БАН-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="дім">
+                    <span class="word-main">das Zuhause</span>
+                    <small class="word-hint">[дас цу-ХАУ-зе]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="без дому">
+                    <span class="word-main">heimatlos</span>
+                    <small class="word-hint">[ХАЙ-мат-лос]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="заслання">
+                    <span class="word-main">die Verbannung</span>
+                    <small class="word-hint">[ди фер-БА-нунг]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="притулок">
+                    притулок
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="вигнати">
+                    вигнати
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="дім">
+                    дім
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="заслання">
+                    заслання
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="бездомний">
+                    бездомний
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="відкинути">
+                    відкинути
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="блукати">
+                    блукати
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="без дому">
+                    без дому
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Verbannung</span>
+                        <small>заслання</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Fremde</span>
+                        <small>чужинець</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Heimat</span>
+                        <small>батьківщина</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Exil</span>
+                        <small>вигнання</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Asyl</span>
+                        <small>притулок</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Zuhause</span>
+                        <small>дім</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>wandern</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>бездомний</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>вигнати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>блукати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>вигнання</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>verbannen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>чужинець</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>заслання</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>вигнати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>батьківщина</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>fortjagen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>відкинути</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>вигнання</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>без дому</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>прогнати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>das Exil</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>вигнати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>заслання</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>вигнання</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>блукати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>das Zuhause</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>без дому</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>дім</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>заслання</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>прогнати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Wo ist mein _____?</p>
+                    <p class="context-hint">Подсказка: Где мой дом?</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Zuhause">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich verlasse meine _____</p>
+                    <p class="context-hint">Подсказка: Я покидаю родину</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Heimat">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich bin _____</p>
+                    <p class="context-hint">Подсказка: Я бездомный</p>
+                    <input type="text" placeholder="Введите слово" data-correct="obdachlos">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Где мой дом</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Zuhause</span><span class="draggable" draggable="true">mein</span><span class="draggable" draggable="true">ist</span><span class="draggable" draggable="true">Wo</span></div>
+                    <div class="drop-zone" data-correct="Wo ist mein Zuhause">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я изгоняю тебя</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">verbanne</span><span class="draggable" draggable="true">dich</span></div>
+                    <div class="drop-zone" data-correct="Ich verbanne dich">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1132,7 +1586,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/emotsii.html
+++ b/output/thematic/lessons/emotsii.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Емоції через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -844,7 +845,496 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="надія">
+                    <span class="word-main">die Hoffnung</span>
+                    <small class="word-hint">[ди ХОФ-нунг]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="страх">
+                    <span class="word-main">die Angst</span>
+                    <small class="word-hint">[ди АНГСТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="каяття">
+                    <span class="word-main">die Reue</span>
+                    <small class="word-hint">[ди РОЙ-е]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="співчуття">
+                    <span class="word-main">das Mitleid</span>
+                    <small class="word-hint">[дас МИТ-лайд]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="радість">
+                    <span class="word-main">die Freude</span>
+                    <small class="word-hint">[ди ФРОЙ-де]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="печаль">
+                    <span class="word-main">die Trauer</span>
+                    <small class="word-hint">[ди ТРАУ-ер]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="ревнощі">
+                    <span class="word-main">die Eifersucht</span>
+                    <small class="word-hint">[ди АЙ-фер-зухт]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="лють">
+                    <span class="word-main">die Wut</span>
+                    <small class="word-hint">[ди ВУТ]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="співчуття">
+                    співчуття
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="ревнощі">
+                    ревнощі
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="радість">
+                    радість
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="страх">
+                    страх
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="лють">
+                    лють
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="каяття">
+                    каяття
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="печаль">
+                    печаль
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="надія">
+                    надія
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Verzweiflung</span>
+                        <small>відчай</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Freude</span>
+                        <small>радість</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Mitleid</span>
+                        <small>співчуття</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Eifersucht</span>
+                        <small>ревнощі</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Angst</span>
+                        <small>страх</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Liebe</span>
+                        <small>любов</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Trauer</span>
+                        <small>печаль</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Reue</span>
+                        <small>каяття</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Zorn</span>
+                        <small>гнів</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>die Freude</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>ревнощі</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>надія</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>радість</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>печаль</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>die Verzweiflung</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>співчуття</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>надія</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>відчай</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>гнів</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>die Eifersucht</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>співчуття</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>лють</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>ревнощі</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>відчай</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Angst</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>каяття</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>надія</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>страх</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>ревнощі</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Reue</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>гнів</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>співчуття</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>каяття</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>радість</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Mein _____ brennt!</p>
+                    <p class="context-hint">Подсказка: Мой гнев пылает!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Zorn">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Meine _____ ist echt</p>
+                    <p class="context-hint">Подсказка: Моя любовь истинна</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Liebe">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ treibt mich</p>
+                    <p class="context-hint">Подсказка: Ненависть движет мной</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Hass">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Мой гнев пылает</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Zorn</span><span class="draggable" draggable="true">Mein</span><span class="draggable" draggable="true">brennt</span></div>
+                    <div class="drop-zone" data-correct="Mein Zorn brennt">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Моя любовь истинна</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">echt</span><span class="draggable" draggable="true">Liebe</span><span class="draggable" draggable="true">Meine</span><span class="draggable" draggable="true">ist</span></div>
+                    <div class="drop-zone" data-correct="Meine Liebe ist echt">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1132,7 +1622,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/final.html
+++ b/output/thematic/lessons/final.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Фінал через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -844,7 +845,484 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="смерть">
+                    <span class="word-main">der Tod</span>
+                    <small class="word-hint">[дер ТОД]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="прощання">
+                    <span class="word-main">der Abschied</span>
+                    <small class="word-hint">[дер АБ-шид]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="труп">
+                    <span class="word-main">die Leiche</span>
+                    <small class="word-hint">[ди ЛАЙ-хе]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="кінець">
+                    <span class="word-main">das Ende</span>
+                    <small class="word-hint">[дас ЕН-де]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="помста">
+                    <span class="word-main">die Rache</span>
+                    <small class="word-hint">[ди РА-хе]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="ховати">
+                    <span class="word-main">begraben</span>
+                    <small class="word-hint">[бе-ГРА-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="плакати">
+                    <span class="word-main">weinen</span>
+                    <small class="word-hint">[ВАЙ-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="горювати">
+                    <span class="word-main">trauern</span>
+                    <small class="word-hint">[ТРАУ-ерн]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="прощання">
+                    прощання
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="труп">
+                    труп
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="ховати">
+                    ховати
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="смерть">
+                    смерть
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="плакати">
+                    плакати
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="кінець">
+                    кінець
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="горювати">
+                    горювати
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="помста">
+                    помста
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Abschied</span>
+                        <small>прощання</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Rache</span>
+                        <small>помста</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Ende</span>
+                        <small>кінець</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Träne</span>
+                        <small>сльоза</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Tod</span>
+                        <small>смерть</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Gerechtigkeit</span>
+                        <small>справедливість</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Schicksal</span>
+                        <small>доля</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Leiche</span>
+                        <small>труп</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>die Leiche</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>справедливість</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>прощання</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>труп</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>смерть</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>trauern</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>кінець</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>труп</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>горювати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>сльоза</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>die Gerechtigkeit</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>справедливість</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>плакати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>ховати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>смерть</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>begraben</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>ховати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>помста</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>смерть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>горювати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>das Ende</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>труп</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>кінець</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>плакати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>прощання</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Das _____ ist gekommen</p>
+                    <p class="context-hint">Подсказка: Конец пришёл</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Ende">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ ist Erlösung</p>
+                    <p class="context-hint">Подсказка: Смерть - избавление</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Tod">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Mein _____ naht</p>
+                    <p class="context-hint">Подсказка: Моё прощание близко</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Abschied">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Конец пришёл</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Ende</span><span class="draggable" draggable="true">Das</span><span class="draggable" draggable="true">gekommen</span><span class="draggable" draggable="true">ist</span></div>
+                    <div class="drop-zone" data-correct="Das Ende ist gekommen">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Смерть - избавление</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">ist</span><span class="draggable" draggable="true">Tod</span><span class="draggable" draggable="true">Der</span><span class="draggable" draggable="true">Erlösung</span></div>
+                    <div class="drop-zone" data-correct="Der Tod ist Erlösung">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1132,7 +1610,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/glagoly_12_dopolnitelnyh.html
+++ b/output/thematic/lessons/glagoly_12_dopolnitelnyh.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Ключові дієслова через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -832,7 +833,359 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="забувати">
+                    <span class="word-main">vergessen</span>
+                    <small class="word-hint">[фер-ГЕ-сен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="лютувати">
+                    <span class="word-main">toben</span>
+                    <small class="word-hint">[ТО-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="любити">
+                    <span class="word-main">lieben</span>
+                    <small class="word-hint">[ЛИ-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="вмирати">
+                    <span class="word-main">sterben</span>
+                    <small class="word-hint">[ШТЕР-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="впізнавати">
+                    <span class="word-main">erkennen</span>
+                    <small class="word-hint">[ер-КЕН-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="прощати">
+                    <span class="word-main">verzeihen</span>
+                    <small class="word-hint">[фер-ЦАЙ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="сподіватися">
+                    <span class="word-main">hoffen</span>
+                    <small class="word-hint">[ХО-фен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="осліпнути">
+                    <span class="word-main">erblinden</span>
+                    <small class="word-hint">[ер-БЛИН-ден]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="сподіватися">
+                    сподіватися
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="вмирати">
+                    вмирати
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="прощати">
+                    прощати
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="лютувати">
+                    лютувати
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="впізнавати">
+                    впізнавати
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="любити">
+                    любити
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="забувати">
+                    забувати
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="осліпнути">
+                    осліпнути
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>erkennen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>осліпнути</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>боротися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>впізнавати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>плакати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>leiden</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>вмирати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>лютувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>страждати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>любити</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>hoffen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>сподіватися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>впізнавати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>лютувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>любити</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>lügen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>боротися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>сподіватися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>брехати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>впізнавати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>verzeihen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>прощати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>боротися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>вмирати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>брехати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Lass mich _____</p>
+                    <p class="context-hint">Подсказка: Дай мне умереть</p>
+                    <input type="text" placeholder="Введите слово" data-correct="sterben">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Кто из вас хочет меня любить</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">mich</span><span class="draggable" draggable="true">will</span><span class="draggable" draggable="true">lieben</span><span class="draggable" draggable="true">von</span><span class="draggable" draggable="true">Wer</span><span class="draggable" draggable="true">euch</span></div>
+                    <div class="drop-zone" data-correct="Wer von euch will mich lieben">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я лгу о своей любви</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">lüge</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">meine</span><span class="draggable" draggable="true">über</span><span class="draggable" draggable="true">Liebe</span></div>
+                    <div class="drop-zone" data-correct="Ich lüge über meine Liebe">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1120,7 +1473,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/glagoly_8_slov.html
+++ b/output/thematic/lessons/glagoly_8_slov.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Дієслова долі через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -844,7 +845,365 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="ділити">
+                    <span class="word-main">teilen</span>
+                    <small class="word-hint">[ТАЙ-лен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="мстити">
+                    <span class="word-main">rächen</span>
+                    <small class="word-hint">[РЕ-хен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="падати">
+                    <span class="word-main">fallen</span>
+                    <small class="word-hint">[ФА-лен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="рятувати">
+                    <span class="word-main">retten</span>
+                    <small class="word-hint">[РЕ-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="обманювати">
+                    <span class="word-main">betrügen</span>
+                    <small class="word-hint">[бе-ТРЮ-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="прокидатися">
+                    <span class="word-main">erwachen</span>
+                    <small class="word-hint">[ер-ВА-хен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="клястися">
+                    <span class="word-main">schwören</span>
+                    <small class="word-hint">[ШВЁ-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="закінчуватися">
+                    <span class="word-main">enden</span>
+                    <small class="word-hint">[ЕН-ден]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="рятувати">
+                    рятувати
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="закінчуватися">
+                    закінчуватися
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="прокидатися">
+                    прокидатися
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="мстити">
+                    мстити
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="ділити">
+                    ділити
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="падати">
+                    падати
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="клястися">
+                    клястися
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="обманювати">
+                    обманювати
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>schwören</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>ділити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>клястися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>рятувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>ховатися</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>teilen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>мстити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>ділити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>обманювати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>закінчуватися</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>betrügen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>ділити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>обманювати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>падати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>закінчуватися</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>wandern</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>блукати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>шкодувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>клястися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>падати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>verfluchen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>шкодувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>блукати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>рятувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>проклинати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Ich will _____</p>
+                    <p class="context-hint">Подсказка: Я хочу упасть</p>
+                    <input type="text" placeholder="Введите слово" data-correct="fallen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Alles muss _____</p>
+                    <p class="context-hint">Подсказка: Всё должно закончиться</p>
+                    <input type="text" placeholder="Введите слово" data-correct="enden">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я делю королевство</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">teile</span><span class="draggable" draggable="true">mein</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">Reich</span></div>
+                    <div class="drop-zone" data-correct="Ich teile mein Reich">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я клянусь в верности</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">Treue</span><span class="draggable" draggable="true">schwöre</span><span class="draggable" draggable="true">dir</span></div>
+                    <div class="drop-zone" data-correct="Ich schwöre dir Treue">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1132,7 +1491,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/haraktery.html
+++ b/output/thematic/lessons/haraktery.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Характери через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -844,7 +845,371 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="наївний">
+                    <span class="word-main">naiv</span>
+                    <small class="word-hint">[на-ИФ]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="сліпий">
+                    <span class="word-main">blind</span>
+                    <small class="word-hint">[БЛИНД]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="добрий">
+                    <span class="word-main">gütig</span>
+                    <small class="word-hint">[ГЮ-тиг]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="гордий">
+                    <span class="word-main">stolz</span>
+                    <small class="word-hint">[ШТОЛЬЦ]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="божевільний">
+                    <span class="word-main">wahnsinnig</span>
+                    <small class="word-hint">[ВАХН-зи-ниг]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="злий">
+                    <span class="word-main">böse</span>
+                    <small class="word-hint">[БЁ-зе]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="чесний">
+                    <span class="word-main">ehrlich</span>
+                    <small class="word-hint">[ЕР-лих]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="вірний">
+                    <span class="word-main">treu</span>
+                    <small class="word-hint">[ТРОЙ]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="вірний">
+                    вірний
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="чесний">
+                    чесний
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="наївний">
+                    наївний
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="сліпий">
+                    сліпий
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="божевільний">
+                    божевільний
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="злий">
+                    злий
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="гордий">
+                    гордий
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="добрий">
+                    добрий
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>treu</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>благородний</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>вірний</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>сліпий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>жорстокий</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>ehrlich</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>благородний</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>добрий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>злий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>чесний</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>stolz</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>добрий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>гордий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>благородний</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>сліпий</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>wahnsinnig</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>злий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>фальшивий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>сліпий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>божевільний</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>edel</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>чесний</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>добрий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>благородний</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>гордий</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Ich bin zu _____</p>
+                    <p class="context-hint">Подсказка: Я слишком горд</p>
+                    <input type="text" placeholder="Введите слово" data-correct="stolz">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Sei _____!</p>
+                    <p class="context-hint">Подсказка: Будь жестокой!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="grausam">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich bin _____</p>
+                    <p class="context-hint">Подсказка: Я добра</p>
+                    <input type="text" placeholder="Введите слово" data-correct="gütig">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я слишком горд</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">stolz</span><span class="draggable" draggable="true">bin</span><span class="draggable" draggable="true">zu</span></div>
+                    <div class="drop-zone" data-correct="Ich bin zu stolz">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я добра</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">bin</span><span class="draggable" draggable="true">gütig</span><span class="draggable" draggable="true">Ich</span></div>
+                    <div class="drop-zone" data-correct="Ich bin gütig">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1132,7 +1497,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/poslaniya.html
+++ b/output/thematic/lessons/poslaniya.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Послання через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -844,7 +845,436 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="надсилати">
+                    <span class="word-main">senden</span>
+                    <small class="word-hint">[ЗЕН-ден]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="попереджати">
+                    <span class="word-main">warnen</span>
+                    <small class="word-hint">[ВАР-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="повідомлення">
+                    <span class="word-main">die Nachricht</span>
+                    <small class="word-hint">[ди НАХ-рихт]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="читати">
+                    <span class="word-main">lesen</span>
+                    <small class="word-hint">[ЛЕ-зен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="шепотіти">
+                    <span class="word-main">flüstern</span>
+                    <small class="word-hint">[ФЛЮС-терн]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="оголошувати">
+                    <span class="word-main">verkünden</span>
+                    <small class="word-hint">[фер-КЮН-ден]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="печатка">
+                    <span class="word-main">das Siegel</span>
+                    <small class="word-hint">[дас ЗИ-гель]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="мовчати">
+                    <span class="word-main">schweigen</span>
+                    <small class="word-hint">[ШВАЙ-ген]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="попереджати">
+                    попереджати
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="шепотіти">
+                    шепотіти
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="печатка">
+                    печатка
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="мовчати">
+                    мовчати
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="повідомлення">
+                    повідомлення
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="надсилати">
+                    надсилати
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="оголошувати">
+                    оголошувати
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="читати">
+                    читати
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Brief</span>
+                        <small>лист</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Nachricht</span>
+                        <small>повідомлення</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Bote</span>
+                        <small>посланець</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Siegel</span>
+                        <small>печатка</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>lesen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>попереджати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>читати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>писати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>печатка</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>verkünden</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>оголошувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>видавати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>писати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>читати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>schweigen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>шепотіти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>посланець</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>повідомлення</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>мовчати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>flüstern</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>видавати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>шепотіти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>надсилати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>писати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>der Bote</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>надсилати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>шепотіти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>печатка</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>посланець</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Dieser _____ beweist alles</p>
+                    <p class="context-hint">Подсказка: Это письмо доказывает всё</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Brief">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Eine _____ vom König</p>
+                    <p class="context-hint">Подсказка: Сообщение от короля</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Nachricht">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Das _____ ist echt</p>
+                    <p class="context-hint">Подсказка: Печать подлинная</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Siegel">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Это письмо доказывает всё</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">alles</span><span class="draggable" draggable="true">Brief</span><span class="draggable" draggable="true">Dieser</span><span class="draggable" draggable="true">beweist</span></div>
+                    <div class="drop-zone" data-correct="Dieser Brief beweist alles">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я пишу Эдмунду</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">an</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">schreibe</span></div>
+                    <div class="drop-zone" data-correct="Ich schreibe an">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1132,7 +1562,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/priroda.html
+++ b/output/thematic/lessons/priroda.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Природа через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -844,7 +845,496 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="дикий">
+                    <span class="word-main">wild</span>
+                    <small class="word-hint">[ВИЛЬД]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="звір">
+                    <span class="word-main">das Tier</span>
+                    <small class="word-hint">[дас ТИР]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="земля">
+                    <span class="word-main">die Erde</span>
+                    <small class="word-hint">[ди ЕР-де]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="печера">
+                    <span class="word-main">die Höhle</span>
+                    <small class="word-hint">[ди ХЁ-ле]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="буря">
+                    <span class="word-main">der Sturm</span>
+                    <small class="word-hint">[дер ШТУРМ]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="блискавка">
+                    <span class="word-main">der Blitz</span>
+                    <small class="word-hint">[дер БЛИЦ]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="природа">
+                    <span class="word-main">die Natur</span>
+                    <small class="word-hint">[ди на-ТУР]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="дощ">
+                    <span class="word-main">der Regen</span>
+                    <small class="word-hint">[дер РЕ-ген]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="дикий">
+                    дикий
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="земля">
+                    земля
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="звір">
+                    звір
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="буря">
+                    буря
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="блискавка">
+                    блискавка
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="печера">
+                    печера
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="природа">
+                    природа
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="дощ">
+                    дощ
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Wind</span>
+                        <small>вітер</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Sturm</span>
+                        <small>буря</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Regen</span>
+                        <small>дощ</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Erde</span>
+                        <small>земля</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Blitz</span>
+                        <small>блискавка</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Höhle</span>
+                        <small>печера</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Himmel</span>
+                        <small>небо</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Donner</span>
+                        <small>грім</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Natur</span>
+                        <small>природа</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>der Blitz</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>буря</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>грім</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>блискавка</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>природа</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>der Himmel</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>земля</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>голий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>небо</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>печера</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>das Tier</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>небо</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>звір</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>вітер</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>голий</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>wild</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>грім</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>блискавка</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>дикий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>природа</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Höhle</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>печера</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>блискавка</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>дощ</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>грім</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Die _____ ist meine Göttin</p>
+                    <p class="context-hint">Подсказка: Природа - моя богиня</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Natur">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ in mir!</p>
+                    <p class="context-hint">Подсказка: Буря во мне!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Sturm">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Schlag zu, _____!</p>
+                    <p class="context-hint">Подсказка: Бей, молния!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Blitz">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Природа - моя богиня</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">meine</span><span class="draggable" draggable="true">Natur</span><span class="draggable" draggable="true">ist</span><span class="draggable" draggable="true">Die</span><span class="draggable" draggable="true">Göttin</span></div>
+                    <div class="drop-zone" data-correct="Die Natur ist meine Göttin">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Буря во мне</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Der</span><span class="draggable" draggable="true">Sturm</span><span class="draggable" draggable="true">mir</span><span class="draggable" draggable="true">in</span></div>
+                    <div class="drop-zone" data-correct="Der Sturm in mir">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1132,7 +1622,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/prirodastihiya.html
+++ b/output/thematic/lessons/prirodastihiya.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Природа і стихія через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -844,7 +845,436 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="темрява">
+                    <span class="word-main">die Finsternis</span>
+                    <small class="word-hint">[ди ФИН-стер-нис]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="знищувати">
+                    <span class="word-main">vernichten</span>
+                    <small class="word-hint">[фер-НИХ-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="безодня">
+                    <span class="word-main">der Abgrund</span>
+                    <small class="word-hint">[дер АБ-грунд]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="розривати">
+                    <span class="word-main">zerreißen</span>
+                    <small class="word-hint">[цер-РАЙ-сен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="холод">
+                    <span class="word-main">die Kälte</span>
+                    <small class="word-hint">[ди КЕЛЬ-те]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="потрясати">
+                    <span class="word-main">erschüttern</span>
+                    <small class="word-hint">[ер-ШЮТ-терн]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="шаленіти">
+                    <span class="word-main">wüten</span>
+                    <small class="word-hint">[ВЮ-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="негода">
+                    <span class="word-main">das Unwetter</span>
+                    <small class="word-hint">[дас УН-вет-тер]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="знищувати">
+                    знищувати
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="шаленіти">
+                    шаленіти
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="холод">
+                    холод
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="темрява">
+                    темрява
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="потрясати">
+                    потрясати
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="негода">
+                    негода
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="розривати">
+                    розривати
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="безодня">
+                    безодня
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Finsternis</span>
+                        <small>темрява</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Kälte</span>
+                        <small>холод</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Unwetter</span>
+                        <small>негода</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Abgrund</span>
+                        <small>безодня</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>erschüttern</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>знищувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>потрясати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>негода</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>лютувати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>zittern</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>тремтіти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>затоплювати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>знищувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>потрясати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>wüten</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>потрясати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>тремтіти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>шаленіти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>знищувати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>toben</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>безодня</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>лютувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>затоплювати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>гриміти</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>donnern</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>лютувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>гриміти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>шаленіти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>потрясати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Lass die Stürme _____!</p>
+                    <p class="context-hint">Подсказка: Пусть бури бушуют!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="toben">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Die Elemente _____</p>
+                    <p class="context-hint">Подсказка: Стихии неистовствуют</p>
+                    <input type="text" placeholder="Введите слово" data-correct="wüten">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Die _____ kommt</p>
+                    <p class="context-hint">Подсказка: Тьма наступает</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Finsternis">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Пусть бури бушуют</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">die</span><span class="draggable" draggable="true">toben</span><span class="draggable" draggable="true">Stürme</span><span class="draggable" draggable="true">Lass</span></div>
+                    <div class="drop-zone" data-correct="Lass die Stürme toben">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я дрожу от холода</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">zittere</span><span class="draggable" draggable="true">vor</span><span class="draggable" draggable="true">Kälte</span><span class="draggable" draggable="true">Ich</span></div>
+                    <div class="drop-zone" data-correct="Ich zittere vor Kälte">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1132,7 +1562,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/put.html
+++ b/output/thematic/lessons/put.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Шлях через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -844,7 +845,472 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="назад">
+                    <span class="word-main">zurück</span>
+                    <small class="word-hint">[цу-РЮК]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="напрямок">
+                    <span class="word-main">die Richtung</span>
+                    <small class="word-hint">[ди РИХ-тунг]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="йти">
+                    <span class="word-main">gehen</span>
+                    <small class="word-hint">[ГЕ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="стежка">
+                    <span class="word-main">der Pfad</span>
+                    <small class="word-hint">[дер ПФАД]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="дорога">
+                    <span class="word-main">die Straße</span>
+                    <small class="word-hint">[ди ШТРА-се]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="слід">
+                    <span class="word-main">die Spur</span>
+                    <small class="word-hint">[ди ШПУР]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="вести">
+                    <span class="word-main">führen</span>
+                    <small class="word-hint">[ФЮ-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="перехрестя">
+                    <span class="word-main">die Kreuzung</span>
+                    <small class="word-hint">[ди КРОЙЦ-унг]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="стежка">
+                    стежка
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="перехрестя">
+                    перехрестя
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="напрямок">
+                    напрямок
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="йти">
+                    йти
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="дорога">
+                    дорога
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="слід">
+                    слід
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="назад">
+                    назад
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="вести">
+                    вести
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Richtung</span>
+                        <small>напрямок</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Spur</span>
+                        <small>слід</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Schritt</span>
+                        <small>крок</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Kreuzung</span>
+                        <small>перехрестя</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Ziel</span>
+                        <small>мета</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Pfad</span>
+                        <small>стежка</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Straße</span>
+                        <small>дорога</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>vorwärts</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>дорога</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>йти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>вперед</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>назад</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>das Ziel</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>вести</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>перехрестя</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>вперед</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>мета</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>der Pfad</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>стежка</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>приходити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>перехрестя</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>йти</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>kommen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>перехрестя</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>слід</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>приходити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>мета</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Spur</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>йти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>назад</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>крок</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>слід</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Der _____ ist dunkel</p>
+                    <p class="context-hint">Подсказка: Тропа темна</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Pfad">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Die _____ endet hier</p>
+                    <p class="context-hint">Подсказка: Дорога кончается здесь</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Straße">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Welche _____?</p>
+                    <p class="context-hint">Подсказка: В каком направлении?</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Richtung">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Тропа темна</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">ist</span><span class="draggable" draggable="true">Pfad</span><span class="draggable" draggable="true">Der</span><span class="draggable" draggable="true">dunkel</span></div>
+                    <div class="drop-zone" data-correct="Der Pfad ist dunkel">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Дорога кончается здесь</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">endet</span><span class="draggable" draggable="true">hier</span><span class="draggable" draggable="true">Straße</span><span class="draggable" draggable="true">Die</span></div>
+                    <div class="drop-zone" data-correct="Die Straße endet hier">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1132,7 +1598,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/puteshestvieskitaniya.html
+++ b/output/thematic/lessons/puteshestvieskitaniya.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Подорож і блукання через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -844,7 +845,436 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="шлях">
+                    <span class="word-main">der Weg</span>
+                    <small class="word-hint">[дер ВЕГ]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="загублений">
+                    <span class="word-main">verloren</span>
+                    <small class="word-hint">[фер-ЛО-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="повертатися додому">
+                    <span class="word-main">heimkehren</span>
+                    <small class="word-hint">[ХАЙМ-ке-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="слідувати">
+                    <span class="word-main">folgen</span>
+                    <small class="word-hint">[ФОЛЬ-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="подорожувати">
+                    <span class="word-main">reisen</span>
+                    <small class="word-hint">[РАЙ-зен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="шукати">
+                    <span class="word-main">suchen</span>
+                    <small class="word-hint">[ЗУ-хен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="далечінь">
+                    <span class="word-main">die Ferne</span>
+                    <small class="word-hint">[ди ФЕР-не]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="блудити">
+                    <span class="word-main">irren</span>
+                    <small class="word-hint">[И-рен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="слідувати">
+                    слідувати
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="далечінь">
+                    далечінь
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="повертатися додому">
+                    повертатися додому
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="загублений">
+                    загублений
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="блудити">
+                    блудити
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="подорожувати">
+                    подорожувати
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="шлях">
+                    шлях
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="шукати">
+                    шукати
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Ferne</span>
+                        <small>далечінь</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Reise</span>
+                        <small>подорож</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Weg</span>
+                        <small>шлях</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Flucht</span>
+                        <small>втеча</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>wandern</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>блудити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>втеча</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>шукати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>блукати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>suchen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>шукати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>блудити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>втеча</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>шлях</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>die Reise</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>подорож</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>шукати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>тікати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>загублений</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>irren</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>блудити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>шукати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>шлях</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>повертатися додому</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>fliehen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>подорож</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>тікати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>загублений</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>втеча</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Ich muss _____</p>
+                    <p class="context-hint">Подсказка: Я должен бежать</p>
+                    <input type="text" placeholder="Введите слово" data-correct="fliehen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ führt ins Nichts</p>
+                    <p class="context-hint">Подсказка: Путь ведет в никуда</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Weg">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Meine _____ endet hier</p>
+                    <p class="context-hint">Подсказка: Мое путешествие кончается</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Reise">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я блуждаю без цели по этому миру</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">wandere</span><span class="draggable" draggable="true">Ziel</span><span class="draggable" draggable="true">ohne</span><span class="draggable" draggable="true">diese</span><span class="draggable" draggable="true">Welt</span><span class="draggable" draggable="true">durch</span></div>
+                    <div class="drop-zone" data-correct="Ich wandere ohne Ziel durch diese Welt">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я должна ехать, отец</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Vater</span><span class="draggable" draggable="true">reisen</span><span class="draggable" draggable="true">muss</span><span class="draggable" draggable="true">Ich</span></div>
+                    <div class="drop-zone" data-correct="Ich muss reisen Vater">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1132,7 +1562,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/semeynyeuzy.html
+++ b/output/thematic/lessons/semeynyeuzy.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Сімейні узи через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -844,7 +845,496 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="родовід">
+                    <span class="word-main">der Stammbaum</span>
+                    <small class="word-hint">[дер ШТАММ-баум]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="дочка">
+                    <span class="word-main">die Tochter</span>
+                    <small class="word-hint">[ди ТОХ-тер]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="вірність">
+                    <span class="word-main">die Treue</span>
+                    <small class="word-hint">[ди ТРОЙ-е]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="кровні узи">
+                    <span class="word-main">die Blutsbande</span>
+                    <small class="word-hint">[ди БЛУТС-бан-де]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="брат">
+                    <span class="word-main">der Bruder</span>
+                    <small class="word-hint">[дер БРУ-дер]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="відректися">
+                    <span class="word-main">verstoßen</span>
+                    <small class="word-hint">[фер-ШТО-сен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="син">
+                    <span class="word-main">der Sohn</span>
+                    <small class="word-hint">[дер ЗОН]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="споріднений">
+                    <span class="word-main">verwandt</span>
+                    <small class="word-hint">[фер-ВАНДТ]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="родовід">
+                    родовід
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="брат">
+                    брат
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="син">
+                    син
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="вірність">
+                    вірність
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="кровні узи">
+                    кровні узи
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="відректися">
+                    відректися
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="споріднений">
+                    споріднений
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="дочка">
+                    дочка
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Stammbaum</span>
+                        <small>родовід</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Tochter</span>
+                        <small>дочка</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Schwester</span>
+                        <small>сестра</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Vater</span>
+                        <small>батько</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Treue</span>
+                        <small>вірність</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Blutsbande</span>
+                        <small>кровні узи</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Erbschaft</span>
+                        <small>спадщина</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Sohn</span>
+                        <small>син</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Bruder</span>
+                        <small>брат</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>die Blutsbande</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>мати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>сестра</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>кровні узи</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>дочка</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>der Vater</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>син</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>вірність</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>споріднений</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>батько</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>der Stammbaum</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>родовід</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>вірність</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>споріднений</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>батько</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Treue</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>мати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>дочка</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>спадщина</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>вірність</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Tochter</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>відректися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>вірність</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>споріднений</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>дочка</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Ich bin euer _____!</p>
+                    <p class="context-hint">Подсказка: Я ваш отец!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Vater">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Eure _____ war besser</p>
+                    <p class="context-hint">Подсказка: Ваша мать была лучше</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Mutter">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich bin Ihre _____</p>
+                    <p class="context-hint">Подсказка: Я ваша дочь</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Tochter">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я ваш отец</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">bin</span><span class="draggable" draggable="true">Vater</span><span class="draggable" draggable="true">euer</span></div>
+                    <div class="drop-zone" data-correct="Ich bin euer Vater">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Ваша мать была лучше</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">war</span><span class="draggable" draggable="true">Mutter</span><span class="draggable" draggable="true">besser</span><span class="draggable" draggable="true">Eure</span></div>
+                    <div class="drop-zone" data-correct="Eure Mutter war besser">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1132,7 +1622,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/semya.html
+++ b/output/thematic/lessons/semya.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Сім'я через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -832,7 +833,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="розлучати">
+                    <span class="word-main">trennen</span>
+                    <small class="word-hint">[ТРЕН-нен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="покоління">
+                    <span class="word-main">die Generation</span>
+                    <small class="word-hint">[ди ге-не-ра-ЦИ-он]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="сім&#x27;я">
+                    <span class="word-main">die Familie</span>
+                    <small class="word-hint">[ди фа-МИ-ли-е]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="ненавидіти">
+                    <span class="word-main">hassen</span>
+                    <small class="word-hint">[ХА-сен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="любити">
+                    <span class="word-main">lieben</span>
+                    <small class="word-hint">[ЛИ-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="батьки">
+                    <span class="word-main">die Eltern</span>
+                    <small class="word-hint">[ди ЕЛЬ-терн]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="спадок">
+                    <span class="word-main">das Erbe</span>
+                    <small class="word-hint">[дас ЕР-бе]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="діти">
+                    <span class="word-main">die Kinder</span>
+                    <small class="word-hint">[ди КИНД-ер]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="спадок">
+                    спадок
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="діти">
+                    діти
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="батьки">
+                    батьки
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="любити">
+                    любити
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="розлучати">
+                    розлучати
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="покоління">
+                    покоління
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="ненавидіти">
+                    ненавидіти
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="сім&#x27;я">
+                    сім&#x27;я
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Ahnen</span>
+                        <small>предки</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Familie</span>
+                        <small>сім&#x27;я</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Eltern</span>
+                        <small>батьки</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Kinder</span>
+                        <small>діти</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Generation</span>
+                        <small>покоління</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Erbe</span>
+                        <small>спадок</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>die Eltern</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>разом</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>батьки</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>виховувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>ненавидіти</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>zusammen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>предки</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>разом</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>об&#x27;єднувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>діти</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>hassen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>розлучати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>об&#x27;єднувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>сім&#x27;я</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>ненавидіти</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>lieben</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>діти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>об&#x27;єднувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>разом</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>любити</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Generation</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>батьки</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>покоління</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>об&#x27;єднувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>предки</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Meine _____ zerfällt</p>
+                    <p class="context-hint">Подсказка: Моя семья распадается</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Familie">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Die _____ sind alt</p>
+                    <p class="context-hint">Подсказка: Родители стары</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Eltern">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Meine _____ hassen mich</p>
+                    <p class="context-hint">Подсказка: Мои дети ненавидят меня</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Kinder">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Моя семья распадается на моих глазах</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Familie</span><span class="draggable" draggable="true">Meine</span><span class="draggable" draggable="true">meinen</span><span class="draggable" draggable="true">vor</span><span class="draggable" draggable="true">Augen</span><span class="draggable" draggable="true">zerfällt</span></div>
+                    <div class="drop-zone" data-correct="Meine Familie zerfällt vor meinen Augen">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Родители слишком стары и слабы</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">alt</span><span class="draggable" draggable="true">sind</span><span class="draggable" draggable="true">Die</span><span class="draggable" draggable="true">Eltern</span><span class="draggable" draggable="true">und</span><span class="draggable" draggable="true">zu</span><span class="draggable" draggable="true">schwach</span></div>
+                    <div class="drop-zone" data-correct="Die Eltern sind zu alt und schwach">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1120,7 +1574,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/vhodyvyhody.html
+++ b/output/thematic/lessons/vhodyvyhody.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Входи і виходи через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -832,7 +833,436 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="покидати">
+                    <span class="word-main">verlassen</span>
+                    <small class="word-hint">[фер-ЛА-сен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="йти геть">
+                    <span class="word-main">fortgehen</span>
+                    <small class="word-hint">[ФОРТ-ге-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="двері">
+                    <span class="word-main">die Tür</span>
+                    <small class="word-hint">[ди ТЮР]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="ворота">
+                    <span class="word-main">das Tor</span>
+                    <small class="word-hint">[дас ТОР]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="тікати">
+                    <span class="word-main">fliehen</span>
+                    <small class="word-hint">[ФЛИ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="прибувати">
+                    <span class="word-main">ankommen</span>
+                    <small class="word-hint">[АН-ком-мен]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="повертатися">
+                    <span class="word-main">zurückkehren</span>
+                    <small class="word-hint">[цу-РЮК-ке-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="вхід">
+                    <span class="word-main">der Eingang</span>
+                    <small class="word-hint">[дер АЙН-ганг]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="прибувати">
+                    прибувати
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="двері">
+                    двері
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="вхід">
+                    вхід
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="ворота">
+                    ворота
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="повертатися">
+                    повертатися
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="покидати">
+                    покидати
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="йти геть">
+                    йти геть
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="тікати">
+                    тікати
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Tür</span>
+                        <small>двері</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Tor</span>
+                        <small>ворота</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Ausgang</span>
+                        <small>вихід</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Eingang</span>
+                        <small>вхід</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>der Ausgang</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>вихід</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>покидати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>виходити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>прибувати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>das Tor</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>двері</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>входити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>виходити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>ворота</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>ankommen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>прибувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>входити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>двері</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>йти геть</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>zurückkehren</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>повертатися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>покидати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>виганяти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>виходити</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>verlassen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>покидати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>вихід</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>вхід</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>тікати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Ich muss dich _____</p>
+                    <p class="context-hint">Подсказка: Я должна тебя покинуть</p>
+                    <input type="text" placeholder="Введите слово" data-correct="verlassen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Schließt die _____ vor ihm!</p>
+                    <p class="context-hint">Подсказка: Закройте дверь перед ним!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Tür">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Das _____ ist verschlossen</p>
+                    <p class="context-hint">Подсказка: Ворота заперты</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Tor">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я вхожу как могущественный король</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">mächtiger</span><span class="draggable" draggable="true">König</span><span class="draggable" draggable="true">als</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">trete</span><span class="draggable" draggable="true">ein</span></div>
+                    <div class="drop-zone" data-correct="Ich trete ein als mächtiger König">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я должна покинуть тебя, отец</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">verlassen</span><span class="draggable" draggable="true">muss</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">Vater</span><span class="draggable" draggable="true">dich</span></div>
+                    <div class="drop-zone" data-correct="Ich muss dich verlassen Vater">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1120,7 +1550,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/videtiponimat.html
+++ b/output/thematic/lessons/videtiponimat.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Бачити і розуміти через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -832,7 +833,424 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="осягати">
+                    <span class="word-main">begreifen</span>
+                    <small class="word-hint">[бе-ГРАЙ-фен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="ясний">
+                    <span class="word-main">klar</span>
+                    <small class="word-hint">[КЛАР]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="очі">
+                    <span class="word-main">die Augen</span>
+                    <small class="word-hint">[ди АУ-ген]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="розкривати">
+                    <span class="word-main">enthüllen</span>
+                    <small class="word-hint">[ент-ХЮЛ-лен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="розуміти">
+                    <span class="word-main">verstehen</span>
+                    <small class="word-hint">[фер-ШТЕ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="зір">
+                    <span class="word-main">die Sicht</span>
+                    <small class="word-hint">[ди ЗИХТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="погляд">
+                    <span class="word-main">der Blick</span>
+                    <small class="word-hint">[дер БЛИК]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="розпізнавати">
+                    <span class="word-main">erkennen</span>
+                    <small class="word-hint">[ер-КЕН-нен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="ясний">
+                    ясний
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="розкривати">
+                    розкривати
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="розпізнавати">
+                    розпізнавати
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="осягати">
+                    осягати
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="погляд">
+                    погляд
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="розуміти">
+                    розуміти
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="очі">
+                    очі
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="зір">
+                    зір
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Sicht</span>
+                        <small>зір</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Blick</span>
+                        <small>погляд</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Augen</span>
+                        <small>очі</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>klar</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>ясний</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>обманювати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>зір</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>розкривати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>verstehen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>зір</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>сліпий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>розуміти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>обманювати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>begreifen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>зір</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>осягати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>сліпий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>погляд</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>erkennen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>розпізнавати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>розуміти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>погляд</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>обманювати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>die Sicht</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>розкривати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>зір</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>розпізнавати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>обманювати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Ich kann nicht mehr _____</p>
+                    <p class="context-hint">Подсказка: Я больше не могу видеть</p>
+                    <input type="text" placeholder="Введите слово" data-correct="sehen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich war _____ vor Stolz</p>
+                    <p class="context-hint">Подсказка: Я был слеп от гордости</p>
+                    <input type="text" placeholder="Введите слово" data-correct="blind">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Reiß ihm die _____ aus!</p>
+                    <p class="context-hint">Подсказка: Вырви ему глаза!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Augen">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я был СЛЕП от гордости</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">vor</span><span class="draggable" draggable="true">Stolz</span><span class="draggable" draggable="true">BLIND</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">war</span></div>
+                    <div class="drop-zone" data-correct="Ich war BLIND vor Stolz">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Теперь я могу ВИДЕТЬ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">SEHEN</span><span class="draggable" draggable="true">Jetzt</span><span class="draggable" draggable="true">kann</span><span class="draggable" draggable="true">ich</span></div>
+                    <div class="drop-zone" data-correct="Jetzt kann ich SEHEN">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1120,7 +1538,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/vlast.html
+++ b/output/thematic/lessons/vlast.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Влада через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -832,7 +833,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="наказувати">
+                    <span class="word-main">befehlen</span>
+                    <small class="word-hint">[бе-ФЕ-лен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="влада">
+                    <span class="word-main">die Macht</span>
+                    <small class="word-hint">[ди МАХТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="царювати">
+                    <span class="word-main">regieren</span>
+                    <small class="word-hint">[ре-ГИ-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="зрікатися">
+                    <span class="word-main">abdanken</span>
+                    <small class="word-hint">[АБ-дан-кен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="панування">
+                    <span class="word-main">die Herrschaft</span>
+                    <small class="word-hint">[ди ХЕРР-шафт]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="корона">
+                    <span class="word-main">die Krone</span>
+                    <small class="word-hint">[ди КРО-не]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="правити">
+                    <span class="word-main">herrschen</span>
+                    <small class="word-hint">[ХЕР-шен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="правитель">
+                    <span class="word-main">der Herrscher</span>
+                    <small class="word-hint">[дер ХЕРРШ-ер]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="панування">
+                    панування
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="правити">
+                    правити
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="влада">
+                    влада
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="царювати">
+                    царювати
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="наказувати">
+                    наказувати
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="корона">
+                    корона
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="зрікатися">
+                    зрікатися
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="правитель">
+                    правитель
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Reich</span>
+                        <small>королівство</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Thron</span>
+                        <small>трон</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Krone</span>
+                        <small>корона</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Macht</span>
+                        <small>влада</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Herrschaft</span>
+                        <small>панування</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Herrscher</span>
+                        <small>правитель</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">vertrauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="trauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>der Herrscher</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>зрікатися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>правитель</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>підкоряти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>королівство</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>befehlen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>наказувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>зрікатися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>влада</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>правитель</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>unterwerfen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>підкоряти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>наказувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>правити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>корона</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>die Macht</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>панування</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>зрікатися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>царювати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>влада</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>der Thron</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>правити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>підкоряти</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>трон</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>правитель</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Die _____ teile ich unter euch</p>
+                    <p class="context-hint">Подсказка: Власть я делю между вами</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Macht">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Jetzt werde ich _____</p>
+                    <p class="context-hint">Подсказка: Теперь я буду править</p>
+                    <input type="text" placeholder="Введите слово" data-correct="herrschen">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ wird mein sein</p>
+                    <p class="context-hint">Подсказка: Трон будет моим</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Thron">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">ВЛАСТЬ я делю</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Die</span><span class="draggable" draggable="true">ich</span><span class="draggable" draggable="true">teile</span><span class="draggable" draggable="true">MACHT</span></div>
+                    <div class="drop-zone" data-correct="Die MACHT teile ich">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Я хочу ОТРЕЧЬСЯ</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">will</span><span class="draggable" draggable="true">ABDANKEN</span><span class="draggable" draggable="true">Ich</span></div>
+                    <div class="drop-zone" data-correct="Ich will ABDANKEN">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1120,7 +1574,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/vlastpredatelstvo.html
+++ b/output/thematic/lessons/vlastpredatelstvo.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Влада і зрада через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -832,7 +833,460 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="зрадник">
+                    <span class="word-main">der Verräter</span>
+                    <small class="word-hint">[дер фер-РЕ-тер]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="зрада">
+                    <span class="word-main">der Verrat</span>
+                    <small class="word-hint">[дер фер-РАТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="заколот">
+                    <span class="word-main">die Verschwörung</span>
+                    <small class="word-hint">[ди фер-ШВЁ-рунг]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="обманути">
+                    <span class="word-main">hintergehen</span>
+                    <small class="word-hint">[хин-тер-ГЕ-ен]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="вірність">
+                    <span class="word-main">die Treue</span>
+                    <small class="word-hint">[ди ТРОЙ-е]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="інтрига">
+                    <span class="word-main">die Intrige</span>
+                    <small class="word-hint">[ди ин-ТРИ-ге]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="змовлятися">
+                    <span class="word-main">verschwören</span>
+                    <small class="word-hint">[фер-ШВЁ-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="обдурити">
+                    <span class="word-main">täuschen</span>
+                    <small class="word-hint">[ТОЙ-шен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="інтрига">
+                    інтрига
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="заколот">
+                    заколот
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="вірність">
+                    вірність
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="зрадник">
+                    зрадник
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="обманути">
+                    обманути
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="зрада">
+                    зрада
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="обдурити">
+                    обдурити
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="змовлятися">
+                    змовлятися
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Verrat</span>
+                        <small>зрада</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Treue</span>
+                        <small>вірність</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Verräter</span>
+                        <small>зрадник</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Komplott</span>
+                        <small>змова</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Verschwörung</span>
+                        <small>заколот</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Intrige</span>
+                        <small>інтрига</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>loyal</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>змовлятися</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>вірний</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>зрада</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>обманути</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>die Intrige</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>вірний</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>невірний</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>змова</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>інтрига</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>der Verrat</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>вірний</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>зрада</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>вірність</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>заколот</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>verraten</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>обманути</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>зрада</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>зраджувати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>заколот</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>der Verräter</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>зрада</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>заколот</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>змова</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>зрадник</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Der _____ meines Sohnes!</p>
+                    <p class="context-hint">Подсказка: Предательство моего сына!</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Verrat">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ein _____ verdient den Tod</p>
+                    <p class="context-hint">Подсказка: Предатель заслуживает смерти</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Verräter">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Ich bleibe _____</p>
+                    <p class="context-hint">Подсказка: Я остаюсь верным</p>
+                    <input type="text" placeholder="Введите слово" data-correct="loyal">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я предаю своего брата ради власти</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">meinen</span><span class="draggable" draggable="true">Macht</span><span class="draggable" draggable="true">für</span><span class="draggable" draggable="true">die</span><span class="draggable" draggable="true">Bruder</span><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">verrate</span></div>
+                    <div class="drop-zone" data-correct="Ich verrate meinen Bruder für die Macht">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Предательство моего сына разбивает мое сердце</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Herz</span><span class="draggable" draggable="true">Der</span><span class="draggable" draggable="true">bricht</span><span class="draggable" draggable="true">Sohnes</span><span class="draggable" draggable="true">mein</span><span class="draggable" draggable="true">Verrat</span><span class="draggable" draggable="true">meines</span></div>
+                    <div class="drop-zone" data-correct="Der Verrat meines Sohnes bricht mein Herz">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1120,7 +1574,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/output/thematic/lessons/zhiznsmert.html
+++ b/output/thematic/lessons/zhiznsmert.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>🎭 Життя і смерть через Короля Ліра</title>
+    <link rel="stylesheet" href="../../css/exercises.css"/>
     <style>
         
 body {
@@ -844,7 +845,436 @@ body {
                 button.classList.toggle('success');
             }
         </script>
+
         
+        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->
+        <section class="exercises-section">
+            <h2 class="section-title">
+                <span class="icon">📚</span> Упражнения
+            </h2>
+            <div class="exercises-accordion">
+
+                <details class="exercise-accordion-item">
+                    <summary>🔗 Подбор слов</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="word-matching">
+                <h3 class="exercise-title">🔗 Подбор слов</h3>
+                <p class="exercise-intro">Соотнесите немецкие слова урока с русскими переводами.</p>
+                <div class="matching-container">
+                    <div class="words-column">
+
+                <div class="word-item" data-id="0" data-answer="вбивати">
+                    <span class="word-main">töten</span>
+                    <small class="word-hint">[ТЁ-тен]</small>
+                </div>
+                
+                <div class="word-item" data-id="1" data-answer="народжувати">
+                    <span class="word-main">gebären</span>
+                    <small class="word-hint">[ге-БЕ-рен]</small>
+                </div>
+                
+                <div class="word-item" data-id="2" data-answer="труп">
+                    <span class="word-main">die Leiche</span>
+                    <small class="word-hint">[ди ЛАЙ-хе]</small>
+                </div>
+                
+                <div class="word-item" data-id="3" data-answer="могила">
+                    <span class="word-main">das Grab</span>
+                    <small class="word-hint">[дас ГРАБ]</small>
+                </div>
+                
+                <div class="word-item" data-id="4" data-answer="живий">
+                    <span class="word-main">lebendig</span>
+                    <small class="word-hint">[ле-БЕН-диг]</small>
+                </div>
+                
+                <div class="word-item" data-id="5" data-answer="мертвий">
+                    <span class="word-main">tot</span>
+                    <small class="word-hint">[ТОТ]</small>
+                </div>
+                
+                <div class="word-item" data-id="6" data-answer="вижити">
+                    <span class="word-main">überleben</span>
+                    <small class="word-hint">[ю-бер-ЛЕ-бен]</small>
+                </div>
+                
+                <div class="word-item" data-id="7" data-answer="життя">
+                    <span class="word-main">das Leben</span>
+                    <small class="word-hint">[дас ЛЕ-бен]</small>
+                </div>
+                
+                    </div>
+                    <div class="translations-column">
+
+                <div class="translation-item" data-id="0" data-trans="народжувати">
+                    народжувати
+                </div>
+                
+                <div class="translation-item" data-id="1" data-trans="живий">
+                    живий
+                </div>
+                
+                <div class="translation-item" data-id="2" data-trans="труп">
+                    труп
+                </div>
+                
+                <div class="translation-item" data-id="3" data-trans="могила">
+                    могила
+                </div>
+                
+                <div class="translation-item" data-id="4" data-trans="мертвий">
+                    мертвий
+                </div>
+                
+                <div class="translation-item" data-id="5" data-trans="вижити">
+                    вижити
+                </div>
+                
+                <div class="translation-item" data-id="6" data-trans="вбивати">
+                    вбивати
+                </div>
+                
+                <div class="translation-item" data-id="7" data-trans="життя">
+                    життя
+                </div>
+                
+                    </div>
+                </div>
+                <button class="check-btn" data-action="check-matching" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🎯 Артикли и род</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="articles">
+                <h3 class="exercise-title">🎯 Артикли и род</h3>
+                <p class="exercise-intro">Выберите правильный артикль для существительных из урока.</p>
+                <div class="articles-grid">
+
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Grab</span>
+                        <small>могила</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="das">
+                    <div class="article-word">
+                        <span class="noun">Leben</span>
+                        <small>життя</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="der">
+                    <div class="article-word">
+                        <span class="noun">Tod</span>
+                        <small>смерть</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                <div class="article-item" data-correct="die">
+                    <div class="article-word">
+                        <span class="noun">Leiche</span>
+                        <small>труп</small>
+                    </div>
+                    <div class="article-buttons">
+                        <button type="button" data-article="der">der</button>
+                        <button type="button" data-article="die">die</button>
+                        <button type="button" data-article="das">das</button>
+                    </div>
+                </div>
+                
+                </div>
+                <button class="check-btn" data-action="check-articles" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🌈 Синонимы и антонимы</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="synonyms">
+                <h3 class="exercise-title">🌈 Синонимы и антонимы</h3>
+                <p class="exercise-intro">Подберите синоним из урока и вспомните противоположное значение.</p>
+
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">der Friede</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="die Welt" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">trauen</span>
+                        <small>доверять</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="vertrauen" data-hint="доверять">
+                        <input type="text" placeholder="Антоним" data-correct="misstrauen" data-hint="не доверять">
+                    </div>
+                </div>
+                
+                <div class="synonym-item">
+                    <div class="word-center">
+                        <span class="word-main">die Welt</span>
+                        <small>мир</small>
+                    </div>
+                    <div class="options">
+                        <input type="text" placeholder="Синоним" data-correct="der Friede" data-hint="мир">
+                        <input type="text" placeholder="Антоним" data-correct="der Krieg" data-hint="война">
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-synonyms" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧠 Викторина по словам</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="quiz">
+                <h3 class="exercise-title">🧠 Викторина по словам</h3>
+
+                <div class="quiz-question" data-question="0">
+                    <p class="question">Как переводится: <strong>leben</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>смерть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="true">
+                            <span>жити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>дихати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-0" data-correct="false">
+                            <span>труп</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="1">
+                    <p class="question">Как переводится: <strong>atmen</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>жити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="true">
+                            <span>дихати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>життя</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-1" data-correct="false">
+                            <span>народжувати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="2">
+                    <p class="question">Как переводится: <strong>der Tod</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>труп</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>вбивати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="true">
+                            <span>смерть</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-2" data-correct="false">
+                            <span>могила</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="3">
+                    <p class="question">Как переводится: <strong>das Leben</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="true">
+                            <span>життя</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>труп</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>живий</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-3" data-correct="false">
+                            <span>смерть</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <div class="quiz-question" data-question="4">
+                    <p class="question">Как переводится: <strong>gebären</strong>?</p>
+                    <div class="quiz-options">
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>життя</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>жити</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="false">
+                            <span>вбивати</span>
+                        </label>
+                    
+                        <label>
+                            <input type="radio" name="quiz-4" data-correct="true">
+                            <span>народжувати</span>
+                        </label>
+                    
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-quiz" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>📝 Контекстный перевод</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="context">
+                <h3 class="exercise-title">📝 Контекстный перевод</h3>
+
+                <div class="context-item">
+                    <p class="context-german">Ich will mit dir _____</p>
+                    <p class="context-hint">Подсказка: Я хочу жить с тобой</p>
+                    <input type="text" placeholder="Введите слово" data-correct="leben">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Lass mich _____</p>
+                    <p class="context-hint">Подсказка: Дай мне умереть</p>
+                    <input type="text" placeholder="Введите слово" data-correct="sterben">
+                </div>
+                
+                <div class="context-item">
+                    <p class="context-german">Der _____ kommt für alle</p>
+                    <p class="context-hint">Подсказка: Смерть приходит за всеми</p>
+                    <input type="text" placeholder="Введите слово" data-correct="Tod">
+                </div>
+                
+                <button class="check-btn" data-action="check-context" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+
+                <details class="exercise-accordion-item">
+                    <summary>🧩 Конструктор предложений</summary>
+                    <div class="exercise-content">
+                        
+            <div class="exercise-block" id="builder">
+                <h3 class="exercise-title">🧩 Конструктор предложений</h3>
+
+                <div class="sentence-builder">
+                    <p class="translation">Я хочу жить с тобой</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Ich</span><span class="draggable" draggable="true">dir</span><span class="draggable" draggable="true">will</span><span class="draggable" draggable="true">leben</span><span class="draggable" draggable="true">mit</span></div>
+                    <div class="drop-zone" data-correct="Ich will mit dir leben">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <div class="sentence-builder">
+                    <p class="translation">Дай мне умереть</p>
+                    <div class="word-pool"><span class="draggable" draggable="true">Lass</span><span class="draggable" draggable="true">sterben</span><span class="draggable" draggable="true">mich</span></div>
+                    <div class="drop-zone" data-correct="Lass mich sterben">
+                        <span class="placeholder">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                
+                <button class="check-btn" data-action="check-builder" type="button">Проверить</button>
+            </div>
+            
+                    </div>
+                </details>
+                
+            </div>
+        </section>
+        
+
         <!-- НАВІГАЦІЯ ПІСЛЯ УПРАЖНЕННЯ -->
         <div class="bottom-navigation">
             <a href="../index.html" class="nav-btn">
@@ -1132,7 +1562,9 @@ body {
         </script>
         
     </div>
-    
+
+    <script src="../../js/exercises.js" defer></script>
+
     <!-- JavaScript для копіювання уроку -->
     <script>
     function copyLesson() {

--- a/src/generators/exercises_assets.py
+++ b/src/generators/exercises_assets.py
@@ -1,0 +1,786 @@
+"""Assets generator for interactive exercises."""
+
+from __future__ import annotations
+
+
+class ExercisesAssetsGenerator:
+    """Provide CSS and JavaScript bundles for interactive exercises."""
+
+    def generate_css(self) -> str:
+        """Return CSS styles for exercises accordion and blocks."""
+
+        return """
+/* ===== СТИЛИ ДЛЯ ИНТЕРАКТИВНЫХ УПРАЖНЕНИЙ ===== */
+
+.exercises-section {
+    margin: 40px 0;
+    padding: 30px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border-radius: 20px;
+    color: #1f2937;
+}
+
+.exercises-section .section-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 24px;
+    color: #ffffff;
+    margin-bottom: 20px;
+}
+
+.exercises-section .section-title .icon {
+    font-size: 30px;
+}
+
+.exercises-accordion {
+    margin-top: 15px;
+}
+
+.exercise-accordion-item {
+    background: #ffffff;
+    border-radius: 12px;
+    margin-bottom: 15px;
+    box-shadow: 0 12px 32px rgba(76, 29, 149, 0.18);
+    overflow: hidden;
+}
+
+.exercise-accordion-item summary {
+    cursor: pointer;
+    padding: 18px 22px;
+    font-size: 18px;
+    font-weight: 600;
+    color: #4338ca;
+    background: rgba(99, 102, 241, 0.08);
+    transition: all 0.3s ease;
+    list-style: none;
+}
+
+.exercise-accordion-item[open] summary {
+    background: rgba(99, 102, 241, 0.16);
+}
+
+.exercise-accordion-item summary::-webkit-details-marker {
+    display: none;
+}
+
+.exercise-accordion-item summary::after {
+    content: '▾';
+    float: right;
+    transition: transform 0.3s ease;
+}
+
+.exercise-accordion-item[open] summary::after {
+    transform: rotate(180deg);
+}
+
+.exercise-content {
+    padding: 20px 24px 30px 24px;
+}
+
+.exercise-block {
+    background: #f9fafb;
+    border-radius: 14px;
+    padding: 20px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.exercise-title {
+    font-size: 20px;
+    margin-bottom: 10px;
+    color: #1f2937;
+}
+
+.exercise-intro {
+    margin: 0 0 15px 0;
+    color: #4b5563;
+}
+
+.check-btn {
+    margin-top: 20px;
+    padding: 12px 28px;
+    background: linear-gradient(135deg, #6366f1 0%, #7c3aed 100%);
+    border: none;
+    color: white;
+    font-weight: 600;
+    border-radius: 10px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 8px 20px rgba(79, 70, 229, 0.35);
+}
+
+.check-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 28px rgba(79, 70, 229, 0.4);
+}
+
+.check-btn:active {
+    transform: translateY(0);
+}
+
+/* Word Matching */
+.matching-container {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.words-column,
+.translations-column {
+    flex: 1;
+    min-width: 260px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.word-item,
+.translation-item {
+    background: white;
+    border-radius: 10px;
+    padding: 14px 16px;
+    border: 2px solid transparent;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 8px 20px rgba(148, 163, 184, 0.25);
+}
+
+.word-item:hover,
+.translation-item:hover {
+    border-color: #c7d2fe;
+}
+
+.word-item.selected,
+.word-item.paired,
+.translation-item.selected {
+    border-color: #6366f1;
+    background: #eef2ff;
+}
+
+.word-item.correct,
+.translation-item.correct {
+    border-color: #10b981;
+    background: #d1fae5;
+}
+
+.word-item.incorrect,
+.translation-item.incorrect {
+    border-color: #ef4444;
+    background: #fee2e2;
+}
+
+/* Articles */
+.articles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+}
+
+.article-item {
+    background: white;
+    border-radius: 12px;
+    padding: 16px;
+    text-align: center;
+    border: 2px solid transparent;
+    transition: border-color 0.2s ease;
+}
+
+.article-word .noun {
+    display: block;
+    font-size: 20px;
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+.article-word small {
+    color: #6b7280;
+}
+
+.article-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.article-buttons button {
+    padding: 8px 16px;
+    border-radius: 8px;
+    background: #f3f4f6;
+    border: 1px solid #d1d5db;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.article-buttons button.selected {
+    background: #6366f1;
+    color: white;
+    border-color: #4f46e5;
+}
+
+.article-buttons button.correct {
+    background: #10b981;
+    border-color: #059669;
+}
+
+.article-buttons button.incorrect {
+    background: #ef4444;
+    border-color: #dc2626;
+    color: white;
+}
+
+/* Synonyms */
+.synonym-item {
+    background: white;
+    border-radius: 12px;
+    padding: 16px;
+    margin-bottom: 14px;
+    display: flex;
+    gap: 18px;
+    align-items: center;
+    box-shadow: 0 6px 14px rgba(79, 70, 229, 0.12);
+}
+
+.word-center {
+    min-width: 160px;
+    text-align: center;
+}
+
+.word-center .word-main {
+    display: block;
+    font-weight: 600;
+    font-size: 20px;
+    color: #4338ca;
+}
+
+.word-center small {
+    color: #6b7280;
+}
+
+.synonym-item input {
+    padding: 10px 14px;
+    border-radius: 8px;
+    border: 2px solid #d1d5db;
+    font-size: 16px;
+    width: 220px;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.synonym-item input:focus {
+    outline: none;
+    border-color: #6366f1;
+    background: #eef2ff;
+}
+
+.synonym-item input.correct {
+    border-color: #10b981;
+    background: #ecfdf5;
+}
+
+.synonym-item input.incorrect {
+    border-color: #ef4444;
+    background: #fef2f2;
+}
+
+/* Quiz */
+.quiz-question {
+    background: white;
+    border-radius: 12px;
+    padding: 18px;
+    margin-bottom: 16px;
+    box-shadow: 0 8px 18px rgba(148, 163, 184, 0.18);
+}
+
+.quiz-question .question {
+    margin-bottom: 14px;
+    font-size: 18px;
+    color: #1f2937;
+}
+
+.quiz-options {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.quiz-options label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: #f9fafb;
+    border-radius: 8px;
+    padding: 10px 12px;
+    border: 2px solid transparent;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.quiz-options label.correct {
+    border-color: #10b981;
+    background: #ecfdf5;
+}
+
+.quiz-options label.incorrect {
+    border-color: #ef4444;
+    background: #fee2e2;
+}
+
+.quiz-options input[type="radio"] {
+    accent-color: #6366f1;
+}
+
+/* Context */
+.context-item {
+    background: white;
+    border-radius: 12px;
+    padding: 18px;
+    margin-bottom: 14px;
+    box-shadow: 0 6px 16px rgba(79, 70, 229, 0.12);
+}
+
+.context-german {
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 8px;
+}
+
+.context-hint {
+    color: #6b7280;
+    margin-bottom: 12px;
+}
+
+.context-item input {
+    width: 100%;
+    padding: 10px 14px;
+    border-radius: 8px;
+    border: 2px solid #d1d5db;
+    font-size: 16px;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.context-item input.correct {
+    border-color: #10b981;
+    background: #ecfdf5;
+}
+
+.context-item input.incorrect {
+    border-color: #ef4444;
+    background: #fef2f2;
+}
+
+/* Sentence builder */
+.sentence-builder {
+    background: white;
+    border-radius: 12px;
+    padding: 20px;
+    margin-bottom: 18px;
+    box-shadow: 0 8px 18px rgba(148, 163, 184, 0.18);
+}
+
+.sentence-builder .translation {
+    margin-bottom: 12px;
+    color: #374151;
+}
+
+.word-pool {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.draggable {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 14px;
+    background: #6366f1;
+    color: white;
+    border-radius: 8px;
+    cursor: grab;
+    user-select: none;
+    transition: transform 0.2s ease;
+}
+
+.draggable:active {
+    cursor: grabbing;
+    transform: scale(0.96);
+}
+
+.drop-zone {
+    min-height: 56px;
+    border: 2px dashed #c7d2fe;
+    border-radius: 10px;
+    padding: 12px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    background: #f5f3ff;
+}
+
+.drop-zone.drag-over {
+    border-color: #4338ca;
+    background: #ede9fe;
+}
+
+.drop-zone.correct {
+    border-color: #10b981;
+}
+
+.drop-zone.incorrect {
+    border-color: #ef4444;
+}
+
+.drop-zone .placeholder {
+    color: #9ca3af;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .exercises-section {
+        padding: 22px;
+    }
+
+    .exercise-content {
+        padding: 16px 18px 24px 18px;
+    }
+
+    .synonym-item {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .synonym-item input {
+        width: 100%;
+    }
+
+    .matching-container {
+        flex-direction: column;
+    }
+
+    .word-pool {
+        justify-content: center;
+    }
+}
+"""
+
+    def generate_js(self) -> str:
+        """Return vanilla JS responsible for exercise interactions."""
+
+        return """
+/* ===== JAVASCRIPT ДЛЯ ИНТЕРАКТИВНЫХ УПРАЖНЕНИЙ ===== */
+
+(function() {
+    'use strict';
+
+    function showResult(message) {
+        if (typeof window !== 'undefined') {
+            window.alert(message);
+        }
+    }
+
+    // 1. Word matching
+    document.addEventListener('click', function(event) {
+        const wordItem = event.target.closest('.word-item');
+        const translationItem = event.target.closest('.translation-item');
+
+        if (wordItem) {
+            document.querySelectorAll('.word-item').forEach(item => {
+                item.classList.remove('selected');
+            });
+            wordItem.classList.add('selected');
+            document.body.dataset.selectedWordId = wordItem.dataset.id;
+        }
+
+        if (translationItem) {
+            const selectedId = document.body.dataset.selectedWordId;
+            if (!selectedId) {
+                return;
+            }
+            const word = document.querySelector(`.word-item[data-id="${selectedId}"]`);
+            if (!word) {
+                return;
+            }
+
+            // Remove previous binding for this word
+            if (word.dataset.selectedId) {
+                const previousTranslation = document.querySelector(`.translation-item[data-id="${word.dataset.selectedId}"]`);
+                if (previousTranslation) {
+                    previousTranslation.classList.remove('selected');
+                    delete previousTranslation.dataset.selectedBy;
+                }
+            }
+
+            // If translation already linked to another word - unlink it
+            if (translationItem.dataset.selectedBy) {
+                const previousWord = document.querySelector(`.word-item[data-id="${translationItem.dataset.selectedBy}"]`);
+                if (previousWord) {
+                    delete previousWord.dataset.selectedId;
+                    previousWord.classList.remove('paired');
+                }
+            }
+
+            translationItem.classList.add('selected');
+            translationItem.dataset.selectedBy = selectedId;
+            word.dataset.selectedId = translationItem.dataset.id;
+            word.dataset.selected = translationItem.dataset.trans;
+            word.classList.add('paired');
+            document.body.dataset.selectedWordId = '';
+        }
+    });
+
+    document.addEventListener('click', function(event) {
+        const action = event.target.closest('[data-action]');
+        if (!action) {
+            return;
+        }
+
+        switch (action.dataset.action) {
+            case 'check-matching':
+                checkMatching();
+                break;
+            case 'check-articles':
+                checkArticles();
+                break;
+            case 'check-synonyms':
+                checkSynonyms();
+                break;
+            case 'check-quiz':
+                checkQuiz();
+                break;
+            case 'check-context':
+                checkContext();
+                break;
+            case 'check-builder':
+                checkBuilder();
+                break;
+            default:
+                break;
+        }
+    });
+
+    function resetClasses(selector) {
+        document.querySelectorAll(selector).forEach(element => {
+            element.classList.remove('correct', 'incorrect');
+        });
+    }
+
+    function checkMatching() {
+        resetClasses('.word-item');
+        resetClasses('.translation-item');
+        const words = document.querySelectorAll('.word-item');
+        let correct = 0;
+
+        words.forEach(word => {
+            const selected = word.dataset.selected;
+            const answer = word.dataset.answer;
+            const translationId = word.dataset.selectedId;
+            if (!selected || !answer) {
+                return;
+            }
+            const translationItem = translationId ? document.querySelector(`.translation-item[data-id="${translationId}"]`) : null;
+            const isCorrect = selected === answer;
+            if (isCorrect) {
+                word.classList.add('correct');
+                if (translationItem) {
+                    translationItem.classList.add('correct');
+                }
+                correct += 1;
+            } else {
+                word.classList.add('incorrect');
+                if (translationItem) {
+                    translationItem.classList.add('incorrect');
+                }
+            }
+        });
+
+        showResult(`Правильно: ${correct} из ${words.length}`);
+    }
+
+    // 2. Articles
+    document.addEventListener('click', function(event) {
+        if (!event.target.matches('.article-buttons button')) {
+            return;
+        }
+        const button = event.target;
+        const container = button.closest('.article-buttons');
+        container.querySelectorAll('button').forEach(item => item.classList.remove('selected'));
+        button.classList.add('selected');
+    });
+
+    function checkArticles() {
+        resetClasses('.article-buttons button');
+        const items = document.querySelectorAll('.article-item');
+        let correct = 0;
+
+        items.forEach(item => {
+            const selected = item.querySelector('.article-buttons button.selected');
+            if (!selected) {
+                return;
+            }
+            if (selected.dataset.article === item.dataset.correct) {
+                selected.classList.add('correct');
+                item.classList.add('correct');
+                correct += 1;
+            } else {
+                selected.classList.add('incorrect');
+                item.classList.add('incorrect');
+            }
+        });
+
+        showResult(`Правильно: ${correct} из ${items.length}`);
+    }
+
+    // 3. Synonyms & Antonyms
+    function checkSynonyms() {
+        const inputs = document.querySelectorAll('#synonyms input');
+        let correct = 0;
+        inputs.forEach(input => {
+            const expected = (input.dataset.correct || '').trim().toLowerCase();
+            const value = (input.value || '').trim().toLowerCase();
+            if (!expected) {
+                return;
+            }
+            if (value === expected) {
+                input.classList.add('correct');
+                input.classList.remove('incorrect');
+                correct += 1;
+            } else {
+                input.classList.add('incorrect');
+                input.classList.remove('correct');
+            }
+        });
+        showResult(`Правильно: ${correct} из ${inputs.length}`);
+    }
+
+    // 4. Quiz
+    function checkQuiz() {
+        const questions = document.querySelectorAll('.quiz-question');
+        let correct = 0;
+        questions.forEach(question => {
+            const options = question.querySelectorAll('label');
+            options.forEach(option => option.classList.remove('correct', 'incorrect'));
+            const selected = question.querySelector('input[type="radio"]:checked');
+            if (!selected) {
+                return;
+            }
+            if (selected.dataset.correct === 'true') {
+                selected.parentElement.classList.add('correct');
+                correct += 1;
+            } else {
+                selected.parentElement.classList.add('incorrect');
+            }
+        });
+        showResult(`Правильно: ${correct} из ${questions.length}`);
+    }
+
+    // 5. Context
+    function checkContext() {
+        const inputs = document.querySelectorAll('#context input');
+        let correct = 0;
+        inputs.forEach(input => {
+            const expected = (input.dataset.correct || '').trim().toLowerCase();
+            const value = (input.value || '').trim().toLowerCase();
+            if (!expected) {
+                return;
+            }
+            if (value === expected) {
+                input.classList.add('correct');
+                input.classList.remove('incorrect');
+                correct += 1;
+            } else {
+                input.classList.add('incorrect');
+                input.classList.remove('correct');
+            }
+        });
+        showResult(`Правильно: ${correct} из ${inputs.length}`);
+    }
+
+    // 6. Sentence builder
+    document.addEventListener('dragstart', function(event) {
+        const draggable = event.target.closest('.draggable');
+        if (!draggable) {
+            return;
+        }
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData('text/plain', draggable.textContent || '');
+        draggable.classList.add('dragging');
+    });
+
+    document.addEventListener('dragend', function(event) {
+        const draggable = event.target.closest('.draggable');
+        if (!draggable) {
+            return;
+        }
+        draggable.classList.remove('dragging');
+    });
+
+    document.addEventListener('dragover', function(event) {
+        const zone = event.target.closest('.drop-zone');
+        if (!zone) {
+            return;
+        }
+        event.preventDefault();
+        zone.classList.add('drag-over');
+    });
+
+    document.addEventListener('dragleave', function(event) {
+        const zone = event.target.closest('.drop-zone');
+        if (!zone) {
+            return;
+        }
+        zone.classList.remove('drag-over');
+    });
+
+    document.addEventListener('drop', function(event) {
+        const zone = event.target.closest('.drop-zone');
+        if (!zone) {
+            return;
+        }
+        event.preventDefault();
+        zone.classList.remove('drag-over');
+        const dragging = document.querySelector('.draggable.dragging');
+        if (!dragging) {
+            return;
+        }
+        const clone = dragging.cloneNode(true);
+        clone.classList.remove('dragging');
+        dragging.remove();
+        zone.appendChild(clone);
+        const placeholder = zone.querySelector('.placeholder');
+        if (placeholder) {
+            placeholder.remove();
+        }
+    });
+
+    function checkBuilder() {
+        const builders = document.querySelectorAll('.sentence-builder');
+        let correct = 0;
+        builders.forEach(builder => {
+            const zone = builder.querySelector('.drop-zone');
+            if (!zone) {
+                return;
+            }
+            const words = Array.from(zone.querySelectorAll('.draggable')).map(item => item.textContent || '');
+            const assembled = words.join(' ').trim();
+            const answer = (zone.dataset.correct || '').trim();
+            if (!answer) {
+                return;
+            }
+            if (assembled === answer) {
+                zone.classList.remove('incorrect');
+                zone.classList.add('correct');
+                correct += 1;
+            } else {
+                zone.classList.remove('correct');
+                zone.classList.add('incorrect');
+            }
+        });
+        showResult(`Правильно: ${correct} из ${builders.length}`);
+    }
+})();
+"""
+
+
+__all__ = ["ExercisesAssetsGenerator"]

--- a/src/generators/exercises_generator.py
+++ b/src/generators/exercises_generator.py
@@ -1,0 +1,594 @@
+"""Interactive exercises generator for lesson pages."""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+from html import escape
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+class ExercisesGenerator:
+    """Generate HTML snippets for interactive lesson exercises."""
+
+    GLOBAL_VOCAB_PATH = (
+        Path(__file__).resolve().parents[2]
+        / "KingLearComic"
+        / "data"
+        / "vocabulary"
+        / "vocabulary.json"
+    )
+
+    def __init__(self, logger: Any = None) -> None:
+        self.logger = logger
+        self.exercises_generated = 0
+        self._global_vocabulary = self._load_global_vocabulary()
+        self._translation_map = self._build_translation_map(self._global_vocabulary)
+        self._antonym_mapping = self._build_antonym_mapping(self._translation_map)
+        self._synonym_lookup, self._synonym_pool = self._build_synonym_pool()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def generate_all_exercises(self, lesson_data: Dict[str, Any]) -> Dict[str, str]:
+        """Generate all exercises for the given lesson."""
+
+        vocabulary = lesson_data.get("vocabulary", []) or []
+        if not vocabulary:
+            return {}
+
+        exercises = {
+            "word_matching": self._generate_word_matching(vocabulary),
+            "articles": self._generate_articles(vocabulary),
+            "synonyms": self._generate_synonyms_antonyms(vocabulary),
+            "quiz": self._generate_vocabulary_quiz(vocabulary),
+            "context": self._generate_context_translation(vocabulary),
+            "builder": self._generate_sentence_builder(
+                lesson_data.get("dialogues", []), lesson_data.get("story")
+            ),
+        }
+
+        self.exercises_generated += sum(1 for value in exercises.values() if value)
+        return exercises
+
+    def create_exercises_section(self, exercises: Dict[str, str]) -> str:
+        """Wrap individual exercises into a single HTML accordion."""
+
+        valid_items = {key: value for key, value in exercises.items() if value}
+        if not valid_items:
+            return ""
+
+        titles = {
+            "word_matching": "🔗 Подбор слов",
+            "articles": "🎯 Артикли и род",
+            "synonyms": "🌈 Синонимы и антонимы",
+            "quiz": "🧠 Викторина по словам",
+            "context": "📝 Контекстный перевод",
+            "builder": "🧩 Конструктор предложений",
+        }
+
+        accordion_items = []
+        for key, title in titles.items():
+            content = valid_items.get(key)
+            if not content:
+                continue
+            accordion_items.append(
+                f"""
+                <details class="exercise-accordion-item">
+                    <summary>{escape(title)}</summary>
+                    <div class="exercise-content">
+                        {content}
+                    </div>
+                </details>
+                """
+            )
+
+        if not accordion_items:
+            return ""
+
+        return (
+            "\n        <!-- РОЗДЕЛ: ИНТЕРАКТИВНЫЕ УПРАЖНЕНИЯ -->\n"
+            "        <section class=\"exercises-section\">\n"
+            "            <h2 class=\"section-title\">\n"
+            "                <span class=\"icon\">📚</span> Упражнения\n"
+            "            </h2>\n"
+            "            <div class=\"exercises-accordion\">\n"
+            + "\n".join(accordion_items)
+            + "\n            </div>\n        </section>\n        "
+        )
+
+    # ------------------------------------------------------------------
+    # Vocabulary helpers
+    # ------------------------------------------------------------------
+    def _load_global_vocabulary(self) -> List[Dict[str, Any]]:
+        if not self.GLOBAL_VOCAB_PATH.exists():
+            if self.logger:
+                self.logger.warning(
+                    "[Exercises] Не знайдено словник для синонимів: %s",
+                    self.GLOBAL_VOCAB_PATH,
+                )
+            return []
+
+        try:
+            data = json.loads(self.GLOBAL_VOCAB_PATH.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            if self.logger:
+                self.logger.error("[Exercises] Неможливо прочитати словник: %s", exc)
+            return []
+
+        vocabulary = data.get("vocabulary", [])
+        if not vocabulary and self.logger:
+            self.logger.warning("[Exercises] Словник не містить лексики")
+        return vocabulary
+
+    def _build_translation_map(
+        self, vocabulary: Iterable[Dict[str, Any]]
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        mapping: Dict[str, List[Dict[str, Any]]] = {}
+        for entry in vocabulary:
+            translation = (entry.get("translation") or "").strip().lower()
+            german = entry.get("german")
+            if not translation or not german:
+                continue
+            mapping.setdefault(translation, []).append(entry)
+        return mapping
+
+    def _build_antonym_mapping(
+        self, translation_map: Dict[str, List[Dict[str, Any]]]
+    ) -> Dict[str, Dict[str, Any]]:
+        mapping: Dict[str, Dict[str, Any]] = {}
+
+        def add_pair(pos: str, neg: str) -> None:
+            pos = pos.strip().lower()
+            neg = neg.strip().lower()
+            if pos in translation_map and neg in translation_map:
+                mapping[pos] = translation_map[neg][0]
+                mapping[neg] = translation_map[pos][0]
+
+        # Пошук автоматичних пар: не- та без-
+        for translation in list(translation_map.keys()):
+            if translation.startswith("не") and len(translation) > 2:
+                base = translation[2:]
+                add_pair(base, translation)
+            if translation.startswith("без ") and len(translation) > 4:
+                base = translation.replace("без ", "", 1)
+                add_pair(base, translation)
+
+        # Ручні пари антонімів для ключових понять сюжету
+        manual_pairs = {
+            "храбрый": "трусливый",
+            "любить": "ненавидеть",
+            "справедливость": "несправедливость",
+            "мир": "война",
+            "друг": "враг",
+            "верность": "предательство",
+            "свет": "тьма",
+            "радость": "печаль",
+            "добрый": "злой",
+            "счастливый": "несчастный",
+        }
+        for positive, negative in manual_pairs.items():
+            add_pair(positive, negative)
+
+        return mapping
+
+    def _build_synonym_pool(self) -> (
+        Dict[str, List[Dict[str, Any]]],
+        List[Dict[str, Any]],
+    ):
+        lookup: Dict[str, List[Dict[str, Any]]] = {}
+        pool: List[Dict[str, Any]] = []
+
+        for translation, entries in self._translation_map.items():
+            antonym_entry = self._antonym_mapping.get(translation)
+            if not antonym_entry:
+                continue
+            antonym_word = antonym_entry.get("german")
+            antonym_translation = antonym_entry.get("translation", "")
+            german_words = [entry.get("german") for entry in entries if entry.get("german")]
+            if len(german_words) < 2 or not antonym_word:
+                continue
+
+            for idx, base_word in enumerate(german_words):
+                synonyms = [word for i, word in enumerate(german_words) if i != idx]
+                if not synonyms:
+                    continue
+                payload = {
+                    "word": base_word,
+                    "synonyms": synonyms,
+                    "translation": translation,
+                    "antonym": antonym_word,
+                    "antonym_translation": antonym_translation,
+                }
+                lookup.setdefault(base_word.lower(), []).append(payload)
+                pool.append(payload)
+
+        return lookup, pool
+
+    # ------------------------------------------------------------------
+    # Individual exercise generators
+    # ------------------------------------------------------------------
+    def _generate_word_matching(self, vocabulary: List[Dict[str, Any]]) -> str:
+        selectable = [word for word in vocabulary if word.get("german") and word.get("translation")]
+        if not selectable:
+            return ""
+
+        sample = random.sample(selectable, min(8, len(selectable)))
+        translations = [escape(word.get("translation", "")) for word in sample]
+        random.shuffle(translations)
+
+        words_html = []
+        for idx, word in enumerate(sample):
+            words_html.append(
+                f"""
+                <div class=\"word-item\" data-id=\"{idx}\" data-answer=\"{escape(word.get('translation', ''))}\">
+                    <span class=\"word-main\">{escape(word.get('german', ''))}</span>
+                    <small class=\"word-hint\">{escape(word.get('transcription', ''))}</small>
+                </div>
+                """
+            )
+
+        translations_html = []
+        for idx, translation in enumerate(translations):
+            translations_html.append(
+                f"""
+                <div class=\"translation-item\" data-id=\"{idx}\" data-trans=\"{translation}\">
+                    {translation}
+                </div>
+                """
+            )
+
+        return (
+            "\n            <div class=\"exercise-block\" id=\"word-matching\">\n"
+            "                <h3 class=\"exercise-title\">🔗 Подбор слов</h3>\n"
+            "                <p class=\"exercise-intro\">Соотнесите немецкие слова урока с русскими переводами.</p>\n"
+            "                <div class=\"matching-container\">\n"
+            "                    <div class=\"words-column\">\n"
+            + "".join(words_html)
+            + "\n                    </div>\n                    <div class=\"translations-column\">\n"
+            + "".join(translations_html)
+            + "\n                    </div>\n                </div>\n"
+            "                <button class=\"check-btn\" data-action=\"check-matching\" type=\"button\">Проверить</button>\n"
+            "            </div>\n            "
+        )
+
+    def _generate_articles(self, vocabulary: List[Dict[str, Any]]) -> str:
+        nouns = []
+        for word in vocabulary:
+            german = word.get("german", "")
+            translation = word.get("translation", "")
+            if not german or not translation:
+                continue
+            parts = german.split()
+            if parts and parts[0].lower() in {"der", "die", "das"}:
+                nouns.append(
+                    {
+                        "article": parts[0].lower(),
+                        "noun": " ".join(parts[1:]) or parts[0],
+                        "translation": translation,
+                    }
+                )
+        if not nouns:
+            return ""
+
+        sample = random.sample(nouns, min(9, len(nouns)))
+        cards_html = []
+        for item in sample:
+            cards_html.append(
+                f"""
+                <div class=\"article-item\" data-correct=\"{escape(item['article'])}\">
+                    <div class=\"article-word\">
+                        <span class=\"noun\">{escape(item['noun'])}</span>
+                        <small>{escape(item['translation'])}</small>
+                    </div>
+                    <div class=\"article-buttons\">
+                        <button type=\"button\" data-article=\"der\">der</button>
+                        <button type=\"button\" data-article=\"die\">die</button>
+                        <button type=\"button\" data-article=\"das\">das</button>
+                    </div>
+                </div>
+                """
+            )
+
+        return (
+            "\n            <div class=\"exercise-block\" id=\"articles\">\n"
+            "                <h3 class=\"exercise-title\">🎯 Артикли и род</h3>\n"
+            "                <p class=\"exercise-intro\">Выберите правильный артикль для существительных из урока.</p>\n"
+            "                <div class=\"articles-grid\">\n"
+            + "".join(cards_html)
+            + "\n                </div>\n"
+            "                <button class=\"check-btn\" data-action=\"check-articles\" type=\"button\">Проверить</button>\n"
+            "            </div>\n            "
+        )
+
+    def _generate_synonyms_antonyms(self, vocabulary: List[Dict[str, Any]]) -> str:
+        pairs = self._select_synonym_pairs(vocabulary)
+        if not pairs:
+            return ""
+
+        items_html = []
+        for pair in pairs:
+            items_html.append(
+                f"""
+                <div class=\"synonym-item\">
+                    <div class=\"word-center\">
+                        <span class=\"word-main\">{escape(pair['word'])}</span>
+                        <small>{escape(pair['translation'])}</small>
+                    </div>
+                    <div class=\"options\">
+                        <input type=\"text\" placeholder=\"Синоним\" data-correct=\"{escape(pair['synonym'])}\" data-hint=\"{escape(pair['translation'])}\">
+                        <input type=\"text\" placeholder=\"Антоним\" data-correct=\"{escape(pair['antonym'])}\" data-hint=\"{escape(pair['antonym_translation'])}\">
+                    </div>
+                </div>
+                """
+            )
+
+        return (
+            "\n            <div class=\"exercise-block\" id=\"synonyms\">\n"
+            "                <h3 class=\"exercise-title\">🌈 Синонимы и антонимы</h3>\n"
+            "                <p class=\"exercise-intro\">Подберите синоним из урока и вспомните противоположное значение.</p>\n"
+            + "".join(items_html)
+            + "\n                <button class=\"check-btn\" data-action=\"check-synonyms\" type=\"button\">Проверить</button>\n"
+            "            </div>\n            "
+        )
+
+    def _generate_vocabulary_quiz(self, vocabulary: List[Dict[str, Any]]) -> str:
+        selectable = [word for word in vocabulary if word.get("german") and word.get("translation")]
+        if not selectable:
+            return ""
+
+        questions = random.sample(selectable, min(5, len(selectable)))
+        blocks = []
+        for idx, word in enumerate(questions):
+            correct = word.get("translation", "")
+            distractors = [w.get("translation", "") for w in selectable if w is not word and w.get("translation")]
+            distractors = list({d for d in distractors if d and d != correct})
+            random.shuffle(distractors)
+            options = [correct] + distractors[:3]
+            random.shuffle(options)
+
+            options_html = []
+            for option in options:
+                state = "true" if option == correct else "false"
+                options_html.append(
+                    f"""
+                        <label>
+                            <input type=\"radio\" name=\"quiz-{idx}\" data-correct=\"{state}\">
+                            <span>{escape(option)}</span>
+                        </label>
+                    """
+                )
+
+            blocks.append(
+                f"""
+                <div class=\"quiz-question\" data-question=\"{idx}\">
+                    <p class=\"question\">Как переводится: <strong>{escape(word.get('german', ''))}</strong>?</p>
+                    <div class=\"quiz-options\">
+                    {''.join(options_html)}
+                    </div>
+                </div>
+                """
+            )
+
+        return (
+            "\n            <div class=\"exercise-block\" id=\"quiz\">\n"
+            "                <h3 class=\"exercise-title\">🧠 Викторина по словам</h3>\n"
+            + "".join(blocks)
+            + "\n                <button class=\"check-btn\" data-action=\"check-quiz\" type=\"button\">Проверить</button>\n"
+            "            </div>\n            "
+        )
+
+    def _generate_context_translation(self, vocabulary: List[Dict[str, Any]]) -> str:
+        contexts = []
+        for word in vocabulary:
+            voice = word.get("character_voice") or {}
+            german_text = voice.get("german")
+            russian_text = voice.get("russian")
+            target = self._normalize_german_word(word.get("german", ""))
+            if not german_text or not russian_text or not target:
+                continue
+            pattern = re.compile(rf"\b{re.escape(target)}\b", re.IGNORECASE)
+            if not pattern.search(german_text):
+                continue
+            blanked = pattern.sub("_____", german_text, count=1)
+            contexts.append(
+                {
+                    "sentence": blanked,
+                    "answer": target,
+                    "hint": russian_text,
+                }
+            )
+            if len(contexts) >= 3:
+                break
+
+        if not contexts:
+            return ""
+
+        rows = []
+        for context in contexts:
+            rows.append(
+                f"""
+                <div class=\"context-item\">
+                    <p class=\"context-german\">{escape(context['sentence'])}</p>
+                    <p class=\"context-hint\">Подсказка: {escape(context['hint'])}</p>
+                    <input type=\"text\" placeholder=\"Введите слово\" data-correct=\"{escape(context['answer'])}\">
+                </div>
+                """
+            )
+
+        return (
+            "\n            <div class=\"exercise-block\" id=\"context\">\n"
+            "                <h3 class=\"exercise-title\">📝 Контекстный перевод</h3>\n"
+            + "".join(rows)
+            + "\n                <button class=\"check-btn\" data-action=\"check-context\" type=\"button\">Проверить</button>\n"
+            "            </div>\n            "
+        )
+
+    def _generate_sentence_builder(
+        self, dialogues: Iterable[Dict[str, Any]], story: Optional[Dict[str, Any]]
+    ) -> str:
+        sentences = self._collect_dialogue_sentences(dialogues)
+        if not sentences and story:
+            sentences = self._collect_story_sentences(story)
+        if not sentences:
+            return ""
+
+        blocks = []
+        for sentence in sentences[:2]:
+            shuffled = sentence["parts"][:]
+            random.shuffle(shuffled)
+            word_pool = "".join(
+                f"<span class=\"draggable\" draggable=\"true\">{escape(word)}</span>"
+                for word in shuffled
+            )
+            blocks.append(
+                f"""
+                <div class=\"sentence-builder\">
+                    <p class=\"translation\">{escape(sentence['translation'])}</p>
+                    <div class=\"word-pool\">{word_pool}</div>
+                    <div class=\"drop-zone\" data-correct=\"{escape(' '.join(sentence['parts']))}\">
+                        <span class=\"placeholder\">Перетащите слова сюда</span>
+                    </div>
+                </div>
+                """
+            )
+
+        return (
+            "\n            <div class=\"exercise-block\" id=\"builder\">\n"
+            "                <h3 class=\"exercise-title\">🧩 Конструктор предложений</h3>\n"
+            + "".join(blocks)
+            + "\n                <button class=\"check-btn\" data-action=\"check-builder\" type=\"button\">Проверить</button>\n"
+            "            </div>\n            "
+        )
+
+    # ------------------------------------------------------------------
+    # Synonym helpers
+    # ------------------------------------------------------------------
+    def _select_synonym_pairs(self, vocabulary: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+        pairs: List[Dict[str, str]] = []
+        used_words = set()
+
+        for word in vocabulary:
+            german = (word.get("german") or "").strip()
+            translation = (word.get("translation") or "").strip()
+            if not german or not translation:
+                continue
+
+            options = self._synonym_lookup.get(german.lower())
+            if not options:
+                continue
+            choice = random.choice(options)
+            synonym = random.choice(choice["synonyms"])
+            antonym = choice["antonym"]
+            antonym_translation = choice["antonym_translation"] or self._translation_for_german(antonym)
+            if not synonym or not antonym:
+                continue
+
+            pairs.append(
+                {
+                    "word": german,
+                    "synonym": synonym,
+                    "translation": translation,
+                    "antonym": antonym,
+                    "antonym_translation": antonym_translation or "Противоположное значение",
+                }
+            )
+            used_words.add(german.lower())
+            if len(pairs) >= 3:
+                break
+
+        if len(pairs) < 3:
+            fallback = [item for item in self._synonym_pool if item["word"].lower() not in used_words]
+            random.shuffle(fallback)
+            for item in fallback:
+                synonym = random.choice(item["synonyms"])
+                antonym_translation = item["antonym_translation"] or self._translation_for_german(item["antonym"])
+                pairs.append(
+                    {
+                        "word": item["word"],
+                        "synonym": synonym,
+                        "translation": item["translation"],
+                        "antonym": item["antonym"],
+                        "antonym_translation": antonym_translation or "Противоположное значение",
+                    }
+                )
+                used_words.add(item["word"].lower())
+                if len(pairs) >= 3:
+                    break
+
+        return pairs[:3]
+
+    def _translation_for_german(self, german: str) -> str:
+        german = (german or "").strip().lower()
+        if not german:
+            return ""
+        for entries in self._translation_map.values():
+            for entry in entries:
+                if entry.get("german", "").strip().lower() == german:
+                    return entry.get("translation", "") or ""
+        return ""
+
+    # ------------------------------------------------------------------
+    # Sentence helpers
+    # ------------------------------------------------------------------
+    def _collect_dialogue_sentences(
+        self, dialogues: Iterable[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        sentences: List[Dict[str, Any]] = []
+        for dialogue in dialogues or []:
+            german = (dialogue.get("german") or "").strip()
+            russian = (dialogue.get("russian") or "").strip()
+            if not german or not russian:
+                continue
+            german_parts = [part.strip() for part in re.split(r"[.!?]+", german) if part.strip()]
+            russian_parts = [part.strip() for part in re.split(r"[.!?]+", russian) if part.strip()]
+            for idx, sentence in enumerate(german_parts):
+                tokens = self._tokenize_sentence(sentence)
+                if len(tokens) < 3:
+                    continue
+                translation = russian_parts[idx] if idx < len(russian_parts) else russian
+                sentences.append({"parts": tokens, "translation": translation})
+                if len(sentences) >= 3:
+                    return sentences
+        return sentences
+
+    def _collect_story_sentences(self, story: Dict[str, Any]) -> List[Dict[str, Any]]:
+        content = (story or {}).get("content")
+        if not content:
+            return []
+        # Видаляємо HTML теги
+        text = re.sub(r"<[^>]+>", " ", content)
+        sentences = []
+        for fragment in re.split(r"[.!?]+", text):
+            fragment = fragment.strip()
+            if not fragment:
+                continue
+            tokens = self._tokenize_sentence(fragment)
+            if len(tokens) < 3:
+                continue
+            sentences.append({"parts": tokens, "translation": fragment})
+            if len(sentences) >= 2:
+                break
+        return sentences
+
+    def _tokenize_sentence(self, sentence: str) -> List[str]:
+        tokens = re.findall(r"[A-Za-zÄÖÜäöüß]+(?:-[A-Za-zÄÖÜäöüß]+)?", sentence)
+        return tokens
+
+    # ------------------------------------------------------------------
+    # Misc helpers
+    # ------------------------------------------------------------------
+    def _normalize_german_word(self, german: str) -> str:
+        german = (german or "").strip()
+        if not german:
+            return ""
+        for article in ("der ", "die ", "das ", "den ", "dem ", "des "):
+            if german.lower().startswith(article):
+                german = german[len(article) :]
+                break
+        return german.strip()
+
+
+__all__ = ["ExercisesGenerator"]

--- a/test/test_exercises_assets.py
+++ b/test/test_exercises_assets.py
@@ -1,0 +1,31 @@
+import unittest
+
+from src.generators.exercises_assets import ExercisesAssetsGenerator
+
+
+class ExercisesAssetsGeneratorTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.generator = ExercisesAssetsGenerator()
+
+    def test_generate_css_contains_core_classes(self) -> None:
+        css = self.generator.generate_css()
+        self.assertIn('.exercises-section', css)
+        self.assertIn('.synonym-item', css)
+        self.assertIn('.drop-zone', css)
+
+    def test_generate_js_defines_handlers(self) -> None:
+        js_code = self.generator.generate_js()
+        for function_name in (
+            'checkMatching',
+            'checkArticles',
+            'checkSynonyms',
+            'checkQuiz',
+            'checkContext',
+            'checkBuilder',
+        ):
+            with self.subTest(function=function_name):
+                self.assertIn(function_name, js_code)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()

--- a/test/test_exercises_generator.py
+++ b/test/test_exercises_generator.py
@@ -1,0 +1,42 @@
+import json
+import random
+from pathlib import Path
+import unittest
+
+from src.generators.exercises_generator import ExercisesGenerator
+
+
+class ExercisesGeneratorTestCase(unittest.TestCase):
+    """Validate HTML snippets created for lessons."""
+
+    def setUp(self) -> None:
+        random.seed(0)
+        lesson_path = Path('data/a2/01_Отец_и_дочери_A2.json')
+        self.lesson_data = json.loads(lesson_path.read_text(encoding='utf-8'))
+        self.generator = ExercisesGenerator()
+
+    def test_generate_all_exercises_returns_html_blocks(self) -> None:
+        bundle = self.generator.generate_all_exercises(self.lesson_data)
+        self.assertEqual(set(bundle.keys()), {
+            'word_matching',
+            'articles',
+            'synonyms',
+            'quiz',
+            'context',
+            'builder',
+        })
+
+        section = self.generator.create_exercises_section(bundle)
+        self.assertIn('exercises-section', section)
+        for block_id in ('word-matching', 'articles', 'synonyms', 'quiz', 'context', 'builder'):
+            with self.subTest(block_id=block_id):
+                self.assertIn(block_id, section)
+
+        # Individual HTML blocks should not be empty strings
+        for name, html in bundle.items():
+            with self.subTest(name=name):
+                self.assertTrue(html.strip())
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an `ExercisesGenerator` that builds the six interactive tasks for each lesson using the shared vocabulary data, plus an assets generator for their styling and behaviour
- integrate the interactive section into the lesson HTML output and emit the supporting CSS/JS assets during site generation
- refresh the generated lesson pages to include the exercises and add unit tests for both the HTML snippets and assets

## Testing
- python -m unittest discover -s test
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68d3cda42ed88320b17cc77c62319e0b