### PR TITLE
Enhance sentence builder controls with hints and per-sentence checks

### DIFF
--- a/src/generators/exercises_assets.py
+++ b/src/generators/exercises_assets.py
@@ -644,11 +644,26 @@ class ExercisesAssetsGenerator:
 @keyframes fadeIn {
     from {
         opacity: 0;
-        transform: translateY(10px);
+        transform: translateX(-50%) translateY(10px);
     }
     to {
         opacity: 1;
-        transform: translateY(0);
+        transform: translateX(-50%) translateY(0);
+    }
+}
+
+@keyframes bounceIn {
+    0% {
+        opacity: 0;
+        transform: translate(-50%, -50%) scale(0.8);
+    }
+    60% {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1.05);
+    }
+    100% {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1);
     }
 }
 
@@ -707,7 +722,7 @@ class ExercisesAssetsGenerator:
     margin-top: 15px;
     align-items: center;
     padding: 10px;
-    background: rgba(139, 92, 246, 0.05);
+    background: rgba(255, 255, 255, 0.05);
     border-radius: 8px;
 }
 
@@ -732,7 +747,6 @@ class ExercisesAssetsGenerator:
 .hint-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
-    background: #9ca3af;
 }
 
 .check-sentence-btn {
@@ -790,7 +804,7 @@ class ExercisesAssetsGenerator:
     position: absolute;
     bottom: 100%;
     left: 50%;
-    transform: translateX(-50%);
+    transform: translateX(-50%) translateY(0);
     background: linear-gradient(135deg, #fbbf24, #f59e0b);
     color: white;
     padding: 10px 15px;
@@ -801,7 +815,6 @@ class ExercisesAssetsGenerator:
     white-space: nowrap;
     animation: fadeIn 0.3s;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-    margin-bottom: 5px;
 }
 
 .hint-tooltip::after {
@@ -895,11 +908,15 @@ class ExercisesAssetsGenerator:
 }
 
 .drop-zone.correct {
-    border-color: #10b981;
+    background: linear-gradient(135deg, rgba(209, 250, 229, 0.3), rgba(16, 185, 129, 0.1));
+    border: 2px solid #10b981;
+    animation: correctPulse 0.6s;
 }
 
 .drop-zone.incorrect {
-    border-color: #ef4444;
+    background: linear-gradient(135deg, rgba(254, 226, 226, 0.3), rgba(239, 68, 68, 0.1));
+    border: 2px solid #ef4444;
+    animation: shake 0.5s;
 }
 
 .drop-zone .placeholder {
@@ -954,6 +971,13 @@ class ExercisesAssetsGenerator:
     let selectedPrompt = null;
     let selectedMatch = null;
     let correctPairs = 0;
+
+    // Sentence builder state tracking
+    let sentenceStates = {};
+    let hintUsage = {};
+    let totalSentences = 0;
+    let correctSentences = 0;
+    let completionShown = false;
     
     window.handleWordClick = function(element, type) {
         // Якщо карточка вже правильна - ігнорувати
@@ -1424,7 +1448,7 @@ class ExercisesAssetsGenerator:
         showResult(`Правильно: ${correct} из ${inputs.length}`);
     }
 
-    // 6. Sentence builder
+    // 6. Sentence builder with individual controls
     document.addEventListener('dragstart', function(event) {
         const draggable = event.target.closest('.draggable');
         if (!draggable) {
@@ -1475,36 +1499,330 @@ class ExercisesAssetsGenerator:
         clone.classList.remove('dragging');
         dragging.remove();
         zone.appendChild(clone);
+
         const placeholder = zone.querySelector('.placeholder');
         if (placeholder) {
             placeholder.remove();
         }
+
+        zone.classList.remove('incorrect', 'correct', 'hint-active');
+
+        const builder = zone.closest('.sentence-builder');
+        if (builder) {
+            const feedback = builder.querySelector('.sentence-feedback');
+            if (feedback) {
+                feedback.textContent = '';
+                feedback.classList.remove('correct', 'incorrect');
+            }
+            const index = resolveBuilderIndex(builder);
+            if (sentenceStates[index]) {
+                return;
+            }
+            const checkBtn = builder.querySelector('.check-sentence-btn');
+            if (checkBtn) {
+                checkBtn.disabled = false;
+                checkBtn.textContent = '✓ Перевірити';
+            }
+        }
+    });
+
+    function resolveBuilderIndex(builder) {
+        if (!builder) {
+            return -1;
+        }
+        const dataIndex = builder.dataset.sentenceIdx;
+        const parsed = Number.parseInt(dataIndex || '', 10);
+        if (!Number.isNaN(parsed)) {
+            return parsed;
+        }
+        const builders = Array.from(document.querySelectorAll('.sentence-builder'));
+        return builders.indexOf(builder);
+    }
+
+    function initializeSentenceBuilder() {
+        const builders = document.querySelectorAll('.sentence-builder');
+        sentenceStates = {};
+        hintUsage = {};
+        totalSentences = builders.length;
+        correctSentences = 0;
+        completionShown = false;
+
+        builders.forEach((builder, idx) => {
+            sentenceStates[idx] = false;
+            hintUsage[idx] = 0;
+
+            const dropZone = builder.querySelector('.drop-zone');
+            if (dropZone) {
+                dropZone.classList.remove('correct', 'incorrect', 'hint-active');
+                dropZone.style.pointerEvents = '';
+                if (!dropZone.children.length) {
+                    const placeholder = document.createElement('span');
+                    placeholder.className = 'placeholder';
+                    placeholder.textContent = 'Перетащите слова сюда';
+                    dropZone.appendChild(placeholder);
+                }
+            }
+
+            const feedback = builder.querySelector('.sentence-feedback');
+            if (feedback) {
+                feedback.textContent = '';
+                feedback.classList.remove('correct', 'incorrect');
+            }
+
+            const hintBtn = builder.querySelector('.hint-btn');
+            if (hintBtn) {
+                hintBtn.disabled = false;
+                hintBtn.textContent = '💡 Підказка';
+            }
+
+            const checkBtn = builder.querySelector('.check-sentence-btn');
+            if (checkBtn) {
+                checkBtn.disabled = false;
+                checkBtn.textContent = '✓ Перевірити';
+            }
+        });
+
+        updateBuilderProgress();
+    }
+
+    function ensureProgressInfo() {
+        const container = document.querySelector('.sentence-builder-section');
+        if (!container) {
+            return null;
+        }
+        let progressInfo = container.querySelector('.progress-info');
+        if (!progressInfo) {
+            progressInfo = document.createElement('div');
+            progressInfo.className = 'progress-info';
+            progressInfo.style.cssText = `
+                margin: 20px 0;
+                padding: 15px;
+                background: rgba(139, 92, 246, 0.1);
+                border-radius: 12px;
+                text-align: center;
+                font-size: 16px;
+                font-weight: 600;
+                color: #8b5cf6;
+            `;
+            const progressBlock = container.querySelector('.builder-progress');
+            if (progressBlock) {
+                container.insertBefore(progressInfo, progressBlock);
+            } else {
+                container.insertBefore(progressInfo, container.firstChild);
+            }
+        }
+        return progressInfo;
+    }
+
+    function updateBuilderProgress() {
+        const percentage = totalSentences ? Math.round((correctSentences / totalSentences) * 100) : 0;
+        const progressFill = document.querySelector('.sentence-builder-section .builder-progress-fill');
+        if (progressFill) {
+            progressFill.style.width = `${percentage}%`;
+        }
+        const stats = document.querySelector('.sentence-builder-section .builder-stats');
+        if (stats) {
+            stats.textContent = `Виконано: ${correctSentences} з ${totalSentences}`;
+        }
+        const progressInfo = ensureProgressInfo();
+        if (progressInfo) {
+            progressInfo.innerHTML = `
+                📊 Прогрес: ${correctSentences} з ${totalSentences} речень (${percentage}%)
+                ${correctSentences === totalSentences && totalSentences > 0 ? '<br>🎉 Вітаємо! Всі речення виконано!' : ''}
+            `;
+        }
+        if (correctSentences === totalSentences && totalSentences > 0 && !completionShown) {
+            completionShown = true;
+            setTimeout(() => {
+                showCompletionMessage();
+            }, 500);
+        }
+    }
+
+    function getRandomBuilderMessage(type) {
+        const messages = {
+            correct: ['✅ Чудово!', '✅ Відмінно!', '✅ Супер!', '✅ Браво!', '✅ Молодець!'],
+            incorrect: ['❌ Спробуйте ще!', '❌ Майже!', '❌ Не здавайтеся!', '❌ Подумайте ще!']
+        };
+        const pool = messages[type] || [];
+        return pool[Math.floor(Math.random() * pool.length)] || '';
+    }
+
+    window.showHint = function(button) {
+        const builder = button.closest('.sentence-builder');
+        if (!builder) {
+            return;
+        }
+        const index = resolveBuilderIndex(builder);
+        if (index < 0) {
+            return;
+        }
+        const dropZone = builder.querySelector('.drop-zone');
+        if (!dropZone) {
+            return;
+        }
+        const correctAnswer = (dropZone.dataset.correct || '').trim();
+        if (!correctAnswer) {
+            return;
+        }
+
+        hintUsage[index] = (hintUsage[index] || 0) + 1;
+
+        const words = correctAnswer.split(new RegExp('\\s+'));
+        let hintWords;
+        if (hintUsage[index] === 1) {
+            hintWords = words.slice(0, Math.min(2, words.length));
+        } else if (hintUsage[index] === 2) {
+            hintWords = words.slice(0, Math.ceil(words.length / 2));
+        } else {
+            hintWords = words.slice(0, Math.max(words.length - 1, 1));
+        }
+        const hintText = `${hintWords.join(' ')}...`;
+
+        dropZone.classList.add('hint-active');
+
+        const existingTooltip = button.querySelector('.hint-tooltip');
+        if (existingTooltip) {
+            existingTooltip.remove();
+        }
+
+        const tooltip = document.createElement('div');
+        tooltip.className = 'hint-tooltip';
+        tooltip.innerHTML = `
+            <strong>Підказка ${Math.min(hintUsage[index], 3)}/3:</strong><br>
+            "${hintText}"
+        `;
+
+        button.style.position = 'relative';
+        button.appendChild(tooltip);
+
+        setTimeout(() => {
+            tooltip.remove();
+            dropZone.classList.remove('hint-active');
+        }, 4000);
+
+        if (hintUsage[index] >= 3) {
+            button.disabled = true;
+            button.textContent = '💡 Використано';
+        }
+    };
+
+    window.checkSentence = function(button) {
+        const builder = button.closest('.sentence-builder');
+        if (!builder) {
+            return;
+        }
+        const dropZone = builder.querySelector('.drop-zone');
+        const feedback = builder.querySelector('.sentence-feedback');
+        if (!dropZone || !feedback) {
+            return;
+        }
+
+        const index = resolveBuilderIndex(builder);
+        if (!(index in sentenceStates)) {
+            sentenceStates[index] = false;
+        }
+
+        const droppedWords = Array.from(dropZone.querySelectorAll('.draggable'))
+            .map(item => (item.textContent || '').trim());
+        const assembled = droppedWords.join(' ').trim();
+        const correctAnswer = (dropZone.dataset.correct || '').trim();
+
+        dropZone.classList.remove('incorrect', 'correct', 'hint-active');
+        feedback.textContent = '';
+        feedback.classList.remove('correct', 'incorrect');
+
+        if (!correctAnswer) {
+            return;
+        }
+
+        if (assembled === correctAnswer) {
+            dropZone.classList.add('correct');
+            feedback.textContent = getRandomBuilderMessage('correct');
+            feedback.classList.add('correct');
+            sentenceStates[index] = true;
+            const hintBtn = builder.querySelector('.hint-btn');
+            if (hintBtn) {
+                hintBtn.disabled = true;
+            }
+            button.disabled = true;
+            button.textContent = '✓ Виконано';
+            dropZone.style.pointerEvents = 'none';
+        } else {
+            dropZone.classList.add('incorrect');
+            feedback.textContent = getRandomBuilderMessage('incorrect');
+            feedback.classList.add('incorrect');
+            sentenceStates[index] = false;
+
+            setTimeout(() => {
+                dropZone.classList.remove('incorrect');
+                if (!sentenceStates[index]) {
+                    feedback.textContent = '';
+                    feedback.classList.remove('incorrect');
+                }
+            }, 2000);
+        }
+
+        correctSentences = Object.values(sentenceStates).filter(Boolean).length;
+        updateBuilderProgress();
+    };
+
+    function showCompletionMessage() {
+        if (document.querySelector('.sentence-builder-complete')) {
+            return;
+        }
+        const modal = document.createElement('div');
+        modal.className = 'sentence-builder-complete';
+        modal.style.cssText = `
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: linear-gradient(135deg, #8b5cf6, #ec4899);
+            color: white;
+            padding: 30px;
+            border-radius: 20px;
+            font-size: 20px;
+            font-weight: bold;
+            text-align: center;
+            z-index: 10000;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+            animation: bounceIn 0.5s;
+        `;
+        modal.innerHTML = `
+            🎉 Вітаємо! 🎉<br>
+            Ви успішно виконали всі завдання!<br>
+            <button class="close-modal" style="
+                margin-top: 20px;
+                padding: 10px 20px;
+                background: white;
+                color: #8b5cf6;
+                border: none;
+                border-radius: 10px;
+                font-size: 16px;
+                font-weight: bold;
+                cursor: pointer;
+            ">Закрити</button>
+        `;
+        const closeButton = modal.querySelector('.close-modal');
+        if (closeButton) {
+            closeButton.addEventListener('click', () => {
+                modal.remove();
+            });
+        }
+        document.body.appendChild(modal);
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        initializeSentenceBuilder();
     });
 
     function checkBuilder() {
-        const builders = document.querySelectorAll('.sentence-builder');
-        let correct = 0;
-        builders.forEach(builder => {
-            const zone = builder.querySelector('.drop-zone');
-            if (!zone) {
-                return;
-            }
-            const words = Array.from(zone.querySelectorAll('.draggable')).map(item => item.textContent || '');
-            const assembled = words.join(' ').trim();
-            const answer = (zone.dataset.correct || '').trim();
-            if (!answer) {
-                return;
-            }
-            if (assembled === answer) {
-                zone.classList.remove('incorrect');
-                zone.classList.add('correct');
-                correct += 1;
-            } else {
-                zone.classList.remove('correct');
-                zone.classList.add('incorrect');
+        document.querySelectorAll('.sentence-builder .check-sentence-btn').forEach(button => {
+            if (!button.disabled) {
+                window.checkSentence(button);
             }
         });
-        showResult(`Правильно: ${correct} из ${builders.length}`);
     }
 })();
 """

--- a/src/generators/exercises_generator.py
+++ b/src/generators/exercises_generator.py
@@ -650,10 +650,7 @@ class ExercisesGenerator:
                 f"<span class=\"draggable\" draggable=\"true\">{escape(word)}</span>"
                 for word in shuffled
             )
-            # Підготовка підказки (перші 2 слова)
-            hint_words = sentence["parts"][:2]
-            hint_text = " ".join(hint_words) + "..."
-            
+
             blocks.append(
                 f"""
                 <div class=\"sentence-builder\" data-sentence-idx=\"{idx}\">
@@ -663,7 +660,7 @@ class ExercisesGenerator:
                         <span class=\"placeholder\">Перетащите слова сюда</span>
                     </div>
                     <div class=\"sentence-controls\">
-                        <button class=\"hint-btn\" onclick=\"showHint(this)\" data-sentence-idx=\"{idx}\" data-hint=\"{escape(hint_text)}\" type=\"button\">
+                        <button class=\"hint-btn\" onclick=\"showHint(this)\" data-sentence-idx=\"{idx}\" type=\"button\">
                             💡 Підказка
                         </button>
                         <button class=\"check-sentence-btn\" onclick=\"checkSentence(this)\" type=\"button\">
@@ -687,7 +684,7 @@ class ExercisesGenerator:
                     <div class=\"builder-progress-bar\">
                         <div class=\"builder-progress-fill\"></div>
                     </div>
-                    <div class=\"builder-stats\">Виконано: <span id=\"builder-correct\">0</span> з {total_sentences}</div>
+                    <div class=\"builder-stats\">Виконано: 0 з {total_sentences}</div>
                 </div>
                 """
             + "".join(blocks)

--- a/test/test_sentence_builder_buttons.py
+++ b/test/test_sentence_builder_buttons.py
@@ -1,0 +1,40 @@
+"""
+Тест: Перевірка оновленого конструктора речень
+Дата: 2025-09-24
+Мета: Тестування індивідуальних кнопок підказок та перевірки
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.generators.exercises_generator import ExercisesGenerator
+
+
+def test_sentence_builder_buttons():
+    generator = ExercisesGenerator()
+
+    test_dialogues = [
+        {
+            "german": "Wozu braucht Ihr das GEFOLGE?",
+            "russian": "Навіщо вам СВИТА?",
+            "words": ["Wozu", "braucht", "Ihr", "das", "GEFOLGE"],
+        }
+    ]
+
+    html = generator._generate_sentence_builder(test_dialogues, None)
+
+    assert 'hint-btn' in html, "[FAIL] Кнопка підказки не знайдена"
+    assert 'check-sentence-btn' in html, "[FAIL] Кнопка перевірки не знайдена"
+    assert 'sentence-controls' in html, "[FAIL] Контейнер контролів не знайдений"
+    assert 'showHint' in html, "[FAIL] Атрибут showHint не знайдено"
+    assert 'checkSentence' in html, "[FAIL] Атрибут checkSentence не знайдено"
+
+    print("[OK] Всі перевірки для конструктора речень пройдено успішно!")
+    print(f"[INFO] HTML містить {html.count('hint-btn')} кнопок підказок")
+    print(f"[INFO] HTML містить {html.count('check-sentence-btn')} кнопок перевірки")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    test_sentence_builder_buttons()


### PR DESCRIPTION
## Summary
- extend the sentence builder markup to include per-sentence hint and check controls with a progress widget for each exercise block
- refresh the sentence builder styling and animations to support the new controls, hint tooltips, and result feedback states
- overhaul the sentence builder JavaScript to provide graduated hints, per-sentence validation, global progress tracking, and completion messaging, plus add a regression test covering the new markup hooks

## Testing
- `python main.py`
- `PYTHONPATH=. pytest test/test_exercises_generator.py test/test_exercises_assets.py test/test_sentence_builder_buttons.py`


------
https://chatgpt.com/codex/tasks/task_e_68d3fa3fd03483208c2c2ac3236e5625