### PR TITLE
Fix runtime update script path handling

### DIFF
--- a/KingLearComic/scripts/update_runtime.py
+++ b/KingLearComic/scripts/update_runtime.py
@@ -1,44 +1,67 @@
+"""Проверка и обновление runtime файлов.
+
+Скрипт використовував абсолютні Windows-шляхи і падав при запуску
+на інших системах. Тепер він визначає директорію проекту відносно
+розташування самого файлу і працює крос-платформенно.
 """
-Проверка и обновление runtime файлов
-"""
 
-source_file = r'F:\AiKlientBank\KingLearComic\static\js\journey_runtime.js'
-output_file = r'F:\AiKlientBank\KingLearComic\output\static\js\journey_runtime.js'
+from __future__ import annotations
 
-# Читаем оба файла
-with open(source_file, 'r', encoding='utf-8') as f:
-    source_content = f.read()
+from pathlib import Path
 
-with open(output_file, 'r', encoding='utf-8') as f:
-    output_content = f.read()
 
-print("[INFO] Анализ файлов...")
-print("=" * 60)
+def _load_file(path: Path) -> str:
+    """Повертає вміст файлу або піднімає зрозумілу помилку."""
 
-# Проверяем наличие russianHint
-source_has_hint = 'russianHint' in source_content
-output_has_hint = 'russianHint' in output_content
+    if not path.exists():
+        raise FileNotFoundError(f"Файл не знайдено: {path}")
+    return path.read_text(encoding="utf-8")
 
-print(f"static/js/journey_runtime.js:")
-print(f"  - Размер: {len(source_content)} символов")
-print(f"  - russianHint: {'НАЙДЕН' if source_has_hint else 'НЕ НАЙДЕН'}")
-if source_has_hint:
-    print(f"  - Вхождений: {source_content.count('russianHint')}")
 
-print(f"\noutput/static/js/journey_runtime.js:")
-print(f"  - Размер: {len(output_content)} символов")
-print(f"  - russianHint: {'НАЙДЕН' if output_has_hint else 'НЕ НАЙДЕН'}")
-if output_has_hint:
-    print(f"  - Вхождений: {output_content.count('russianHint')}")
+def main() -> int:
+    base_dir = Path(__file__).resolve().parent.parent
+    source_file = base_dir / "static" / "js" / "journey_runtime.js"
+    output_file = base_dir / "output" / "static" / "js" / "journey_runtime.js"
 
-# Если в output есть, а в source нет - копируем
-if output_has_hint and not source_has_hint:
-    print("\n[ACTION] Копирование обновленного файла из output в static...")
-    with open(source_file, 'w', encoding='utf-8') as f:
-        f.write(output_content)
-    print("[OK] Файл скопирован!")
-    print("[OK] Теперь нужно перегенерировать сайт!")
-elif source_has_hint:
-    print("\n[OK] Исходный файл уже содержит russianHint")
-else:
-    print("\n[ERROR] russianHint не найден ни в одном файле!")
+    print("[INFO] Аналіз файлів...")
+    print("=" * 60)
+
+    try:
+        source_content = _load_file(source_file)
+        output_content = _load_file(output_file)
+    except FileNotFoundError as error:
+        print(f"[ERROR] {error}")
+        print("[HINT] Запустіть генерацію сайту перед оновленням runtime.")
+        return 1
+
+    source_has_hint = "russianHint" in source_content
+    output_has_hint = "russianHint" in output_content
+
+    print("static/js/journey_runtime.js:")
+    print(f"  - Розмір: {len(source_content)} символів")
+    print(f"  - russianHint: {'ЗНАЙДЕНО' if source_has_hint else 'НЕ ЗНАЙДЕНО'}")
+    if source_has_hint:
+        print(f"  - Входжень: {source_content.count('russianHint')}")
+
+    print("\noutput/static/js/journey_runtime.js:")
+    print(f"  - Розмір: {len(output_content)} символів")
+    print(f"  - russianHint: {'ЗНАЙДЕНО' if output_has_hint else 'НЕ ЗНАЙДЕНО'}")
+    if output_has_hint:
+        print(f"  - Входжень: {output_content.count('russianHint')}")
+
+    if output_has_hint and not source_has_hint:
+        print("\n[ACTION] Копіювання оновленого файлу з output до static...")
+        source_file.write_text(output_content, encoding="utf-8")
+        print("[OK] Файл скопійовано!")
+        print("[OK] Перегенеруйте сайт, щоб застосувати зміни.")
+    elif source_has_hint:
+        print("\n[OK] Початковий файл вже містить russianHint")
+    else:
+        print("\n[ERROR] russianHint не знайдено ні в одному файлі!")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - допоміжний скрипт
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- replace the hardcoded Windows paths in `KingLearComic/scripts/update_runtime.py` with dynamic path resolution based on the script location
- add basic error handling and clearer console messages while keeping the russianHint copy logic unchanged

## Testing
- python KingLearComic/scripts/update_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68d4187d2c10832090fabb8948b785fd