### PR TITLE
Adjust tablet layout for word matching exercise

### DIFF
--- a/output/css/exercises.css
+++ b/output/css/exercises.css
@@ -115,6 +115,7 @@
     display: flex;
     gap: 24px;
     flex-wrap: wrap;
+    align-items: flex-start;
 }
 
 .words-column,
@@ -931,11 +932,18 @@
         width: 100%;
     }
 
+    .word-pool {
+        justify-content: center;
+    }
+}
+
+@media (max-width: 640px) {
     .matching-container {
         flex-direction: column;
     }
 
-    .word-pool {
-        justify-content: center;
+    .words-column,
+    .translations-column {
+        min-width: 100%;
     }
 }

--- a/src/generators/exercises_assets.py
+++ b/src/generators/exercises_assets.py
@@ -126,6 +126,7 @@ class ExercisesAssetsGenerator:
     display: flex;
     gap: 24px;
     flex-wrap: wrap;
+    align-items: flex-start;
 }
 
 .words-column,
@@ -942,12 +943,19 @@ class ExercisesAssetsGenerator:
         width: 100%;
     }
 
+    .word-pool {
+        justify-content: center;
+    }
+}
+
+@media (max-width: 640px) {
     .matching-container {
         flex-direction: column;
     }
 
-    .word-pool {
-        justify-content: center;
+    .words-column,
+    .translations-column {
+        min-width: 100%;
     }
 }
 """


### PR DESCRIPTION
## Summary
- keep the word-matching exercise columns aligned side-by-side on tablet widths
- update the generator and compiled CSS so small phones still stack the columns cleanly

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4229b122483208e3b0b9a357497cb